### PR TITLE
As a System Admin, I want MarkLogic licensing appropriately handled for containers

### DIFF
--- a/dockerFiles/marklogic-server-centos:base
+++ b/dockerFiles/marklogic-server-centos:base
@@ -46,7 +46,9 @@ ENV MARKLOGIC_INSTALL_DIR=/opt/MarkLogic  \
     MARKLOGIC_VERSION="${ML_VERSION}" \
     MARKLOGIC_BOOTSTRAP_HOST=bootstrap \
     MARKLOGIC_ADMIN_USERNAME_FILE=mldb_admin_user \
-    MARKLOGIC_ADMIN_PASSWORD_FILE=mldb_password_user
+    MARKLOGIC_ADMIN_PASSWORD_FILE=mldb_password_user \
+    MARKLOGIC_LICENSE=mldb_liense \
+    MARKLOGIC_LICENSEE=mldb_licensee
 
 ###############################################################
 # inject init, start and clustering scripts

--- a/src/centos/scripts/start-marklogic.sh
+++ b/src/centos/scripts/start-marklogic.sh
@@ -64,7 +64,7 @@ then
 echo "MARKLOGIC_INIT is not defined, no bootstrap"
 else
 echo "MARKLOGIC_INIT is defined, bootstrapping"
-#curl -X POST -d "" http://$HOSTNAME:8001/admin/v1/init
+
 curl --anyauth -i -X POST \
    -H "Content-type:application/x-www-form-urlencoded" \
    --data-urlencode $MARKLOGIC_LICENSE \

--- a/src/centos/scripts/start-marklogic.sh
+++ b/src/centos/scripts/start-marklogic.sh
@@ -64,7 +64,12 @@ then
 echo "MARKLOGIC_INIT is not defined, no bootstrap"
 else
 echo "MARKLOGIC_INIT is defined, bootstrapping"
-curl -X POST -d "" http://$HOSTNAME:8001/admin/v1/init
+#curl -X POST -d "" http://$HOSTNAME:8001/admin/v1/init
+curl --anyauth -i -X POST \
+   -H "Content-type:application/x-www-form-urlencoded" \
+   --data-urlencode $MARKLOGIC_LICENSE \
+   --data-urlencode $MARKLOGIC_LICENSEE \
+   http://$HOSTNAME:8001/admin/v1/init
 sleep 5s
 curl -X POST -H "Content-type: application/x-www-form-urlencoded" \
      --data "admin-username=$ML_ADMIN_USERNAME" --data "admin-password=$ML_ADMIN_PASSWORD" \


### PR DESCRIPTION
* Given there is an official MarkLogic docker image available at docker-hub, when I need to create a MarkLogic instance, then I should able to supply MarkLogic license as a paramater during container startup so I have a licensed MarkLogic cluster

* able to apply developer or essential enterprise license 

* Given I have already supplied the license information during the container startup, I should be able to change the license at a later point via admin gui