### PR TITLE
CLD-525 Add version and branch to Docker log

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,7 +195,7 @@ def StructureTests() {
     sh """
         cd test
         #insert current version
-        sed -i -e 's/VERSION_PLACEHOLDER/${mlVersion}-${env.platformString}-${env.dockerVersion}/' ./structure-test.yaml
+        sed -i -e 's/VERSION_PLACEHOLDER/${mlVersion}-${env.platformString}-${env.dockerVersion}/g' -e 's/BRANCH_PLACEHOLDER/${env.BRANCH_NAME}/g' ./structure-test.yaml
         cd ..
         curl -s -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64 && chmod +x container-structure-test-linux-amd64 && mv container-structure-test-linux-amd64 container-structure-test
         make structure-test version=${mlVersion}-${env.platformString}-${env.dockerVersion} Jenkins=true
@@ -292,7 +292,7 @@ pipeline {
 
         stage('Build-Image') {
             steps {
-                sh "make build version=${mlVersion}-${env.platformString}-${env.dockerVersion} package=${RPM} converters=${CONVERTERS}"
+                sh "make build version=${mlVersion}-${env.platformString}-${env.dockerVersion} build_branch=${env.BRANCH_NAME} package=${RPM} converters=${CONVERTERS}"
             }
         }
 
@@ -322,7 +322,7 @@ pipeline {
                 expression { return params.DOCKER_TESTS }
             }
             steps {
-                sh "make docker-tests test_image=marklogic-centos/marklogic-server-centos:${mlVersion}-${env.platformString}-${env.dockerVersion}"
+                sh "make docker-tests test_image=marklogic-centos/marklogic-server-centos:${mlVersion}-${env.platformString}-${env.dockerVersion} version=${mlVersion}-${env.platformString}-${env.dockerVersion} build_branch=${env.BRANCH_NAME}"
                 junit testResults: '**/test_results/docker-tests.xml'
                 publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: 'test/test_results', reportFiles: 'report.html', reportName: 'Docker Tests Report', reportTitles: ''])
             }

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,15 @@ REPONAME=marklogic-centos
 repoDir="marklogic"
 docker_build_options=--compress
 test_image?=ml-docker-dev.marklogic.com/${repoDir}/marklogic-server-centos:${version}
+build_branch?=local
 
 #***************************************************************************
 # build docker images
 #***************************************************************************
 build:
 	cd src/centos/; docker build ${docker_build_options} -t "${REPONAME}/marklogic-deps-centos:${version}" -f ../../dockerFiles/marklogic-deps-centos:base .
-	cd src/centos/; docker build ${docker_build_options} -t "${REPONAME}/marklogic-server-centos:${version}" --build-arg BASE_IMAGE=${REPONAME}/marklogic-deps-centos:${version} --build-arg ML_RPM=${package} --build-arg ML_USER=marklogic_user --build-arg ML_VERSION=${version} --build-arg ML_CONVERTERS=${converters} -f ../../dockerFiles/marklogic-server-centos:base .
- 
+	cd src/centos/; docker build ${docker_build_options} -t "${REPONAME}/marklogic-server-centos:${version}" --build-arg BASE_IMAGE=${REPONAME}/marklogic-deps-centos:${version} --build-arg ML_RPM=${package} --build-arg ML_USER=marklogic_user --build-arg ML_VERSION=${version} --build-arg ML_CONVERTERS=${converters} --build-arg BUILD_BRANCH=${build_branch} -f ../../dockerFiles/marklogic-server-centos:base .
+
 #***************************************************************************
 # strcture test docker images
 #***************************************************************************
@@ -23,7 +24,7 @@ structure-test:
 # docker image tests
 #***************************************************************************
 docker-tests: 
-	cd test; robot -x docker-tests.xml --outputdir test_results --variable TEST_IMAGE:${test_image} ./docker-tests.robot
+	cd test; robot -x docker-tests.xml --outputdir test_results --variable TEST_IMAGE:${test_image} --variable MARKLOGIC_VERSION:${version} --variable BUILD_BRANCH:${build_branch} ./docker-tests.robot
 
 #***************************************************************************
 # run all tests

--- a/dockerFiles/marklogic-server-centos:base
+++ b/dockerFiles/marklogic-server-centos:base
@@ -55,6 +55,7 @@ COPY --from=builder / /
 
 ARG ML_USER="marklogic_user"
 ARG ML_VERSION=10-internal
+ARG BUILD_BRANCH=local
 ###############################################################
 # define docker labels
 ###############################################################
@@ -65,10 +66,10 @@ LABEL "com.marklogic.version"="1.0.0"
 LABEL "com.marklogic"="MarkLogic"
 LABEL "com.marklogic.release-type"="production"
 LABEL "com.marklogic.release-version"="${ML_VERSION}"
+LABEL "com.marklogic.build-branch"="${BUILD_BRANCH}"
 LABEL "com.marklogic.license"="MarkLogic EULA"
 LABEL "com.marklogic.license.description"="By subscribing to this product, you agree to the terms and conditions outlined in MarkLogic's End User License Agreement (EULA) here https://developer.marklogic.com/eula "
 LABEL "com.marklogic.license.url"="https://developer.marklogic.com/eula"
-LABEL "com.marklogic.version"="${ML_VERSION}"
 LABEL "com.marklogic.description"="MarkLogic is the only Enterprise NoSQL database. It is a new generation database built with a flexible data model to store, manage, and search JSON, XML, RDF, and more - without sacrificing enterprise features such as ACID transactions, certified security, backup, and recovery. With these capabilities, MarkLogic is ideally suited for making heterogeneous data integration simpler and faster, and for delivering dynamic content at massive scale. The current release of the MarkLogic Server Developer Docker image includes all features and is limited to developer use."
 LABEL docker.cmd="docker run -it -p 7997-8010:7997-8010 -e MARKLOGIC_INIT=true -e MARKLOGIC_ADMIN_USERNAME=<INSERT USERNAME> -e MARKLOGIC_ADMIN_PASSWORD=<INSERT PASSWORD> --mount src=MarkLogic,dst=/var/opt/MarkLogic marklogicdb/marklogic-db:${ML_VERSION}"
 
@@ -87,7 +88,9 @@ ENV MARKLOGIC_INSTALL_DIR=/opt/MarkLogic  \
     MARKLOGIC_BOOTSTRAP_HOST=bootstrap \
     MARKLOGIC_ADMIN_USERNAME_FILE=mldb_admin_user \
     MARKLOGIC_ADMIN_PASSWORD_FILE=mldb_password_user \
-    MARKLOGIC_WALLET_PASSWORD_FILE=mldb_wallet_password
+    MARKLOGIC_WALLET_PASSWORD_FILE=mldb_wallet_password \
+    BUILD_BRANCH=${BUILD_BRANCH}
+    
 
 ###############################################################
 # expose MarkLogic server ports

--- a/src/centos/scripts/start-marklogic.sh
+++ b/src/centos/scripts/start-marklogic.sh
@@ -12,15 +12,6 @@
 ###############################################################
 
 ###############################################################
-# Prepare script
-###############################################################
-cd ~ || exit
-# Convert booleans to lowercase
-for var in OVERWRITE_ML_CONF INSTALL_CONVERTERS MARKLOGIC_DEV_BUILD MARKLOGIC_INIT MARKLOGIC_JOIN_CLUSTER; do
-    declare $var="$(echo "${!var}" | sed -e 's/[[:blank:]]//g' | awk '{print tolower($0)}')"
-done
-
-###############################################################
 # Define log and err functions
 ###############################################################
 log() {
@@ -30,6 +21,16 @@ err() {
     echo "$(basename "${0}") ERROR: ${*}" >&2
     exit 1
 }
+
+###############################################################
+# Prepare script
+###############################################################
+log "Starting MarkLogic container with $MARKLOGIC_VERSION from $BUILD_BRANCH"
+cd ~ || exit
+# Convert booleans to lowercase
+for var in OVERWRITE_ML_CONF INSTALL_CONVERTERS MARKLOGIC_DEV_BUILD MARKLOGIC_INIT MARKLOGIC_JOIN_CLUSTER; do
+    declare $var="$(echo "${!var}" | sed -e 's/[[:blank:]]//g' | awk '{print tolower($0)}')"
+done
 
 ###############################################################
 # Set Hostname to the value of hostname command to /etc/marklogic.conf when MARKLOGIC_FQDN_SUFFIX is set.

--- a/test/docker-tests.robot
+++ b/test/docker-tests.robot
@@ -9,6 +9,7 @@ Uninitialized MarkLogic container
   Create container with  -e  MARKLOGIC_INIT=false
   Docker log should contain  *MARKLOGIC_JOIN_CLUSTER is false or not defined, not joining cluster.*
   Docker log should contain  *MARKLOGIC_INIT is set to false or not defined, not initialzing.*
+  Docker log should contain  *Starting MarkLogic container with ${MARKLOGIC_VERSION} from ${BUILD_BRANCH}*
   Verify response for unauthenticated request with  8000  *Forbidden*
   Verify response for unauthenticated request with  8001  *This server must now self-install the initial databases and application servers. Click OK to continue.*
   Verify response for unauthenticated request with  8002  *Forbidden*
@@ -23,6 +24,7 @@ Initialized MarkLogic container
   ...                    -e  MARKLOGIC_ADMIN_PASSWORD=${DEFAULT ADMIN PASS}
   Docker log should contain  *MARKLOGIC_JOIN_CLUSTER is false or not defined, not joining cluster.*
   Docker log should contain  *MARKLOGIC_INIT is true, initialzing.*
+  Docker log should contain  *Starting MarkLogic container with ${MARKLOGIC_VERSION} from ${BUILD_BRANCH}*
   Verify response for unauthenticated request with  8000  *Unauthorized*
   Verify response for unauthenticated request with  8001  *Unauthorized*
   Verify response for unauthenticated request with  8002  *Unauthorized*

--- a/test/keywords.resource
+++ b/test/keywords.resource
@@ -12,6 +12,8 @@ ${TEST_IMAGE}  %{DOCKER_TEST_IMAGE=marklogic-centos/marklogic-server-centos:10-i
 ${DOCKER TIMEOUT}  90s
 ${LICENSE KEY}  %{QA_LICENSE_KEY=none}
 ${LICENSEE}  MarkLogic - Version 9 QA Test License
+${MARKLOGIC_VERSION}  10-internal
+${BUILD_BRANCH}  local
 
 *** Keywords ***
 Create container with

--- a/test/structure-test.yaml
+++ b/test/structure-test.yaml
@@ -18,6 +18,8 @@ metadataTest:
       value: /opt/MarkLogic
     - key: MARKLOGIC_UMASK
       value: 022
+    - key: BUILD_BRANCH
+      value: BRANCH_PLACEHOLDER
   labels:
     - key: "com.marklogic.maintainer"
       value: "docker@marklogic.com"
@@ -33,6 +35,15 @@ metadataTest:
       value: "By subscribing to this product, you agree to the terms and conditions outlined in MarkLogic's End User License Agreement (EULA) here https://developer.marklogic.com/eula "
     - key: "com.marklogic.license.url"
       value: "https://developer.marklogic.com/eula"
+    - key: "com.marklogic.name"
+      value: "MarkLogic Server VERSION_PLACEHOLDER"
+    - key: "com.marklogic.version"
+      value: "1.0.0"
+    - key: "com.marklogic.release-version"
+      value: "VERSION_PLACEHOLDER"
+    - key: "com.marklogic.build-branch"
+      value: "BRANCH_PLACEHOLDER"
+    
   exposedPorts: ["7997","8001","8002","8003","8004","8005","8006","8007","8009","8010"]
   volumes: ["/var/opt/MarkLogic"]
   entrypoint: ["/usr/local/bin/start-marklogic.sh"]


### PR DESCRIPTION
This PR is for CLD-525 and it adds MarkLogic version and build branch to Docker log as well as Docker metadata. Also there are additional tests to verify updated metadata and the log message.