### PR TITLE
CLD-546 Fix Jenkins pipeline to report failed tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,7 +110,7 @@ def getServerPath(branchName) {
     }
 }
 
-def ResultNotification(message) {
+void ResultNotification(message) {
     def author, authorEmail, emailList
     if (env.CHANGE_AUTHOR) {
         author = env.CHANGE_AUTHOR.toString().trim().toLowerCase()
@@ -130,7 +130,7 @@ def ResultNotification(message) {
     }
 }
 
-def CopyRPMs() {
+void CopyRPMs() {
     timeStamp = sh(returnStdout: true, script: 'date +%Y%m%d').trim()
     sh """
         cd src/centos
@@ -194,7 +194,7 @@ def CopyRPMs() {
     }
 }
 
-def StructureTests() {
+void StructureTests() {
     sh """
         cd test
         #insert current version
@@ -207,7 +207,7 @@ def StructureTests() {
     """
 }
 
-def ServerRegressionTests() {
+void ServerRegressionTests() {
     //TODO: run this conditionally for develop and master branches only
     echo 'Server regression tests would execute here'
     // The following can be uncommented to show an interactive prompt for manual regresstion tests
@@ -243,7 +243,7 @@ void Scan() {
     sh '''rm -f scan-server-image.txt'''
 }
 
-def PublishToInternalRegistry() {
+void PublishToInternalRegistry() {
     withCredentials([usernamePassword(credentialsId: '8c2e0b38-9e97-4953-aa60-f2851bb70cc8', passwordVariable: 'docker_password', usernameVariable: 'docker_user')]) {
         sh """
             docker login -u ${docker_user} -p ${docker_password} ${dockerRegistry}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -205,7 +205,6 @@ def StructureTests() {
         #fix junit output
         sed -i -e 's/<\\/testsuites>//' -e 's/<testsuite>//' -e 's/<testsuites/<testsuite name="container-structure-test"/' ./container-structure-test.xml
     """
-    junit testResults: '**/container-structure-test.xml'
 }
 
 def ServerRegressionTests() {
@@ -251,6 +250,11 @@ def PublishToInternalRegistry() {
             make push-mlregistry version=${mlVersion}-${env.platformString}-${env.dockerVersion}
         """
     }
+}
+
+void publishTestResults() {
+    junit testResults: '**/test_results/docker-tests.xml,**/container-structure-test.xml'
+    publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: 'test/test_results', reportFiles: 'report.html', reportName: 'Docker Tests Report', reportTitles: ''])
 }
 
 pipeline {
@@ -333,8 +337,6 @@ pipeline {
             }
             steps {
                 sh "make docker-tests test_image=marklogic-centos/marklogic-server-centos:${mlVersion}-${env.platformString}-${env.dockerVersion} version=${mlVersion}-${env.platformString}-${env.dockerVersion} build_branch=${env.BRANCH_NAME}"
-                junit testResults: '**/test_results/docker-tests.xml'
-                publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: true, reportDir: 'test/test_results', reportFiles: 'report.html', reportName: 'Docker Tests Report', reportTitles: ''])
             }
         }
 
@@ -369,6 +371,7 @@ pipeline {
                 docker volume prune --force
                 docker image prune --force --all
             '''
+            publishTestResults()
         }
         success {
             ResultNotification('BUILD SUCCESS ✅')


### PR DESCRIPTION
- separate test result publishing so that reports would generate even when tests fail
- extra: fix package locators in order to allow the builds from 10.0 (default), 11.0 and 9.0