### PR TITLE
Fix typo causing bug

### DIFF
--- a/src/centos/scripts/start-marklogic.sh
+++ b/src/centos/scripts/start-marklogic.sh
@@ -87,8 +87,8 @@ fi
 # Install Converters if required
 ################################################################
 if [[ "${INSTALL_CONVERTERS}" == "true" ]]; then
-    if [[ -d "/opt/MarkLogic/Converters" ]]; then
-        info "Converters directory: /opt/MarkLogic/Converters already exists, skipping installation of converters."
+    if [[ -d "var//opt/MarkLogic/Converters" ]]; then
+        info "Converters directory: var/opt/MarkLogic/Converters already exists, skipping installation of converters."
     else
         info "INSTALL_CONVERTERS is true, installing converters."
         CONVERTERS_PATH="/converters.rpm"

--- a/src/centos/scripts/start-marklogic.sh
+++ b/src/centos/scripts/start-marklogic.sh
@@ -210,7 +210,7 @@ fi
 ################################################################
 # check marklogic init (eg. MARKLOGIC_INIT is set)
 ################################################################
-if [[ -f /opt/MarkLogic/DOCKER_INIT ]]; then
+if [[ -f /var/opt/MarkLogic/DOCKER_INIT ]]; then
     info "MARKLOGIC_INIT is true, but the server is already initialized. Skipping initialization."
 elif [[ "${MARKLOGIC_INIT}" == "true" ]]; then
     info "MARKLOGIC_INIT is true, initializing the MarkLogic server."
@@ -261,7 +261,7 @@ elif [[ "${MARKLOGIC_INIT}" == "true" ]]; then
         -d \"admin-username=${ML_ADMIN_USERNAME}\" -d \"admin-password=${ML_ADMIN_PASSWORD}\" \
         -d \"realm=${ML_REALM}\" -d \"${ML_WALLET_PASSWORD_PAYLOAD}\""
 
-    sudo touch /opt/MarkLogic/DOCKER_INIT
+    sudo touch /var/opt/MarkLogic/DOCKER_INIT
 elif [[ -z "${MARKLOGIC_INIT}" ]] || [[ "${MARKLOGIC_INIT}" == "false" ]]; then
     info "MARKLOGIC_INIT is set to false or not defined, not initializing."
 else
@@ -271,7 +271,7 @@ fi
 ################################################################
 # check join cluster (eg. MARKLOGIC_JOIN_CLUSTER is set and host is not bootstrap host)
 ################################################################
-if [[ -f /opt/MarkLogic/DOCKER_JOIN_CLUSTER ]]; then
+if [[ -f /var/opt/MarkLogic/DOCKER_JOIN_CLUSTER ]]; then
     info "MARKLOGIC_JOIN_CLUSTER is true, but skipping join because this instance has already joined a cluster."
 elif [[ "${MARKLOGIC_JOIN_CLUSTER}" == "true" ]] && [[ "${HOSTNAME}" != "${MARKLOGIC_BOOTSTRAP_HOST}" ]]; then
     info "MARKLOGIC_JOIN_CLUSTER is true and join conditions are met, joining host to the cluster."
@@ -299,7 +299,7 @@ elif [[ "${MARKLOGIC_JOIN_CLUSTER}" == "true" ]] && [[ "${HOSTNAME}" != "${MARKL
 
     rm -f host.xml
     rm -f cluster.zip
-    sudo touch /opt/MarkLogic/DOCKER_JOIN_CLUSTER
+    sudo touch /var/opt/MarkLogic/DOCKER_JOIN_CLUSTER
 elif [[ -z "${MARKLOGIC_JOIN_CLUSTER}" ]] || [[ "${MARKLOGIC_JOIN_CLUSTER}" == "false" ]] || [[ "${HOSTNAME}" == "${MARKLOGIC_BOOTSTRAP_HOST}" ]]; then
     info "MARKLOGIC_JOIN_CLUSTER is false or not defined, not joining cluster."
 else


### PR DESCRIPTION
The persistent volume is var/opt/Marklogic so when we were writing to opt/Marklogic the file wouldn't persist after the pod went down leading to the container thinking it had to initialize again when it came back up. Also changed join cluster path for the same reason. 

Converters logic has the same issue but I wasn't sure if it would end up with the same issue, if so lines 90 and 91 will need to be updated as well. 