### PR TITLE
Remove copy-and-paste error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,8 +362,6 @@ $ docker ps
 ```
 This command lists all the Docker containers running on the host.
 
-After the containers are initialized, you can access the MarkLogic Query Console on http://localhost:8000 and the MarkLogic Admin UI at http://localhost:8001. These ports can also be accessed externally via your hostname or IP address.
-
 As in the previous single-node example, each node of the cluster can be accessed with localhost or host machine IP address. The MarkLogic Query Console and MarkLogic Admin UI ports for each container will be different. The ports are defined in the compose file created previously: http://localhost:7101, http://localhost:7201, http://localhost:7301, etc.
 
 ### Using ENV for admin credentials in Docker compose


### PR DESCRIPTION
It seems this paragraph was left over after copying from previous section.  It does not make sense, especially not with the following paragraph.
