### PR TITLE
CLD-658 Update branch names for the server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,6 +121,8 @@ void resultNotification(message) {
 String getServerVersion(branchName) {
     switch (branchName) {
         case 'develop':
+            return '12.0'
+        case 'develop-11':
             return '11.0'
         case 'develop-10.0':
             return '10.0'
@@ -133,7 +135,7 @@ String getServerVersion(branchName) {
 
 void copyRPMs() {
     timeStamp = sh(returnStdout: true, script: 'date +%Y%m%d').trim()
-    if (buildServerVersion == "11.0") {
+    if (buildServerVersion == "11.0" || buildServerVersion == "12.0") {
         RPMsuffix = ".${timeStamp}-rhel"
     }
     else {
@@ -294,7 +296,7 @@ pipeline {
         string(name: 'emailList', defaultValue: emailList, description: 'List of email for build notification', trim: true)
         string(name: 'dockerVersion', defaultValue: '1.0.0', description: 'ML Docker version. This version along with ML rpm package version will be the image tag as {ML_Version}_{dockerVersion}', trim: true)
         string(name: 'platformString', defaultValue: 'centos', description: 'Platform string for Docker image version. Will be made part of the docker image tag', trim: true)
-        choice(name: 'ML_SERVER_BRANCH', choices: 'develop-10.0\ndevelop\ndevelop-9.0', description: 'MarkLogic Server Branch. used to pick appropriate rpm')
+        choice(name: 'ML_SERVER_BRANCH', choices: 'develop-11\ndevelop\ndevelop-10.0\ndevelop-9.0', description: 'MarkLogic Server Branch. used to pick appropriate rpm')
         string(name: 'ML_RPM', defaultValue: '', description: 'RPM to be used for Image creation. \n If left blank nightly ML rpm will be used.\n Please provide Jenkins accessible path e.g. /project/engineering or /project/qa', trim: true)
         string(name: 'ML_CONVERTERS', defaultValue: '', description: 'The Converters RPM to be included in the image creation \n If left blank the nightly ML Converters Package will be used.', trim: true)
         booleanParam(name: 'PUBLISH_IMAGE', defaultValue: false, description: 'Publish image to internal registry')


### PR DESCRIPTION
### Description
Pushing directly to develop as Jenkinsfile changes are only used on develop.
After ML11 release develop branch on the server side now refers to the next major release of MarkLogic: 12. So our branch references need to be updated to build with develop-10, develop-11 (current) and develop.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
