### PR TITLE
CLD-632: ML Start script is not able to translate special characters for admin password

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Example run:
 ```
 $ docker run -d -it -p 8000:8000 -p 8001:8001 -p 8002:8002 \ 
      -e MARKLOGIC_INIT=true \
-     -e MARKLOGIC_ADMIN_USERNAME=admin \
-     -e MARKLOGIC_ADMIN_PASSWORD=Areally!PowerfulPassword1337 \
+     -e MARKLOGIC_ADMIN_USERNAME='admin' \
+     -e MARKLOGIC_ADMIN_PASSWORD='Areally!PowerfulPassword1337' \
      marklogicdb/marklogic-db:10.0-9.5-centos-1.0.0
 ```
 Wait about a minute for MarkLogic Server to initialize before checking the ports. To verify the successful installation and initialization, log into the MarkLogic Server Admin Interface using the admin credentials used in the command above. Go to http://localhost:8001. You can also verify the configuration by following the procedures outlined in the MarkLogic Server documentation. See the MarkLogic Installation documentation [here](https://docs.marklogic.com/guide/installation/procedures#id_84772).

--- a/src/centos/scripts/start-marklogic.sh
+++ b/src/centos/scripts/start-marklogic.sh
@@ -263,8 +263,8 @@ elif [[ "${MARKLOGIC_INIT}" == "true" ]]; then
         TIMESTAMP=$(curl -s --anyauth "http://${HOSTNAME}:8001/admin/v1/timestamp")
 
         curl_retry_validate "http://${HOSTNAME}:8001/admin/v1/instance-admin" 202 "-o /dev/null \
-            -X POST -H \"Content-type:application/x-www-form-urlencoded\" \
-            -d \"admin-username=${ML_ADMIN_USERNAME}\" --data-urlencode 'admin-password=${ML_ADMIN_PASSWORD}' \
+            -X POST -H \"Content-type:application/x-www-form-urlencoded; charset=utf-8\" \
+            -d \"admin-username=${ML_ADMIN_USERNAME}\" --data-urlencode \"admin-password=${ML_ADMIN_PASSWORD}\" \
             -d \"realm=${ML_REALM}\" -d \"${ML_WALLET_PASSWORD_PAYLOAD}\""
 
         restart_check "${HOSTNAME}" "${TIMESTAMP}"

--- a/src/centos/scripts/start-marklogic.sh
+++ b/src/centos/scripts/start-marklogic.sh
@@ -220,7 +220,7 @@ elif [[ "${MARKLOGIC_INIT}" == "true" ]]; then
 
     # Make sure username and password variables are not empty
     if [[ -z "${ML_ADMIN_USERNAME}" ]] || [[ -z "${ML_ADMIN_PASSWORD}" ]]; then
-        error "ML_ADMIN_USERNAME and ML_ADMIN_PASSWORD must be set." exit
+        error "MARKLOGIC_ADMIN_USERNAME and MARKLOGIC_ADMIN_PASSWORD must be set." exit
     fi
 
     # generate JSON payload conditionally with license details.
@@ -264,7 +264,7 @@ elif [[ "${MARKLOGIC_INIT}" == "true" ]]; then
 
         curl_retry_validate "http://${HOSTNAME}:8001/admin/v1/instance-admin" 202 "-o /dev/null \
             -X POST -H \"Content-type:application/x-www-form-urlencoded\" \
-            -d \"admin-username=${ML_ADMIN_USERNAME}\" -d \"admin-password=${ML_ADMIN_PASSWORD}\" \
+            -d \"admin-username=${ML_ADMIN_USERNAME}\" --data-urlencode 'admin-password=${ML_ADMIN_PASSWORD}' \
             -d \"realm=${ML_REALM}\" -d \"${ML_WALLET_PASSWORD_PAYLOAD}\""
 
         restart_check "${HOSTNAME}" "${TIMESTAMP}"


### PR DESCRIPTION
fix for handling special chars in admin pwd & updated error msg and readme

