### PR TITLE
CLD-767: Remove eval and update param sequence in curl retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ settings.json
 .mark.config
 *.rpm
 test/test_results/*
+test/log.html
+test/report.html
+test/output.xml

--- a/src/centos/scripts/start-marklogic.sh
+++ b/src/centos/scripts/start-marklogic.sh
@@ -238,6 +238,7 @@ function curl_retry_validate {
     if [[ "${return_error}" = "false" ]] ; then
         return "${response_code}"
     fi
+    [ -f "start-marklogic_curl_retry_validate.log" ] && cat start-marklogic_curl_retry_validate.log
     error "Expected response code ${expected_response_code}, got ${response_code} from ${endpoint}." exit
 }
 

--- a/src/centos/scripts/start-marklogic.sh
+++ b/src/centos/scripts/start-marklogic.sh
@@ -193,8 +193,8 @@ function validate_tls_parameters {
 ################################################################
 function validate_cert {
     local cacertfile=$1
-    local request response
-    request=$(curl -s -S -L --cacert "${cacertfile}" --ssl "${ML_BOOTSTRAP_PROTOCOL}"://"${MARKLOGIC_BOOTSTRAP_HOST}":8001 --anyauth --user "${ML_ADMIN_USERNAME}":"${ML_ADMIN_PASSWORD}")
+    local response
+    curl -s -S -L --cacert "${cacertfile}" --ssl "${ML_BOOTSTRAP_PROTOCOL}"://"${MARKLOGIC_BOOTSTRAP_HOST}":8001 --anyauth --user "${ML_ADMIN_USERNAME}":"${ML_ADMIN_PASSWORD}"
     response=$?
     if [ $response -ne 0 ]; then
         error "MARKLOGIC_JOIN_CACERT_FILE is not valid, please check above error for details. Node shutting down." exit
@@ -202,29 +202,29 @@ function validate_cert {
 }
 
 ################################################################
-# retry_and_timeout(target_url, expected_response_code, additional_options, return_error)
-# The third argument is optional and can be used to pass additional options to curl.
-# Fourth argurment is optional, default is set to true, can be used when custom error handling is required,
-# if set to true means function will return error and exit if curl fails N_RETRY times
-# setting to false means function will return response code instead of failing and exiting.
+# curl_retry_validate(return_error, endpoint, expected_response_code, curl_options)
 # Retry a curl command until it returns the expected response
 # code or fails N_RETRY times.
 # Use RETRY_INTERVAL to tune the test length.
 # Validate that response code is the same as expected response
 # code or exit with an error.
 #
-#   $1 :  The target url to test against
-#   $2 :  The expected response code
-#   $3 :  Additional options to pass to curl
-#   $4 :  Option to return error or response code in case of error   
+#   $1 :  Option to return error or response code in case of error 
+#   $2 :  The target url to test against
+#   $3 :  The expected response code
+#   $4+:  Additional options to pass to curl
 ################################################################
 function curl_retry_validate {
-    local retry_count response_code request
-    local return_error="${4:-true}" curl_options=$3 endpoint=$1
+    local retry_count response_code
+    local return_error=$1; shift
+    local endpoint=$1; shift
+    local expected_response_code=$1; shift
+    local curl_options=("$@")
+
     for ((retry_count = 0; retry_count < N_RETRY; retry_count = retry_count + 1)); do
-        request="curl -m 30 -s -w '%{http_code}' $curl_options $endpoint"
-        response_code=$(eval "${request}")
-        if [[ ${response_code} -eq $2 ]]; then
+        response_code=$(curl -m 30 -s -w '%{http_code}' "${curl_options[@]}" "$endpoint")
+
+        if [[ ${response_code} -eq ${expected_response_code} ]]; then
             return "${response_code}"
         fi
         sleep ${RETRY_INTERVAL}
@@ -232,7 +232,7 @@ function curl_retry_validate {
     if [[ "${return_error}" = "false" ]] ; then
         return "${response_code}"
     fi
-    error "Expected response code ${2}, got ${response_code} from ${1}." exit
+    error "Expected response code ${expected_response_code}, got ${response_code} from ${endpoint}." exit
 }
 
 ################################################################
@@ -261,8 +261,8 @@ function get_host_id {
     hostname=$1 
     host_id=""
     ML_BOOTSTRAP_PROTOCOL=$(get_host_protocol "${hostname}")
-    curl_retry_validate "${ML_BOOTSTRAP_PROTOCOL}://${hostname}:8001/admin/v1/server-config" 200 "--anyauth --user \"${ML_ADMIN_USERNAME}\":\"${ML_ADMIN_PASSWORD}\" \
-            -o host_config.xml -X GET -H \"Accept: application/xml\" --cacert \"${ML_CACERT_FILE}\"" false
+    curl_retry_validate false "${ML_BOOTSTRAP_PROTOCOL}://${hostname}:8001/admin/v1/server-config" 200 \
+            "--anyauth" "--user" "${ML_ADMIN_USERNAME}:${ML_ADMIN_PASSWORD}" "-o" "host_config.xml" "-X" "GET" "-H" "Accept: application/xml" "--cacert" "${ML_CACERT_FILE}"
     [[ -f host_config.xml ]] && host_id=$(< host_config.xml grep "host-id" | sed 's%^.*<host-id.*>\(.*\)</host-id>.*$%\1%')
     echo "${host_id}"
     rm -f host_config.xml
@@ -335,10 +335,6 @@ else
     ML_WALLET_PASSWORD="${MARKLOGIC_WALLET_PASSWORD}"
 fi
 
-# escape $ in password variables
-ML_ADMIN_PASSWORD="${ML_ADMIN_PASSWORD//$/\\$}"
-ML_WALLET_PASSWORD="${ML_WALLET_PASSWORD//$/\\$}"
-
 ################################################################
 # check marklogic init (eg. MARKLOGIC_INIT is set)
 ################################################################
@@ -406,9 +402,8 @@ elif [[ "${MARKLOGIC_INIT}" == "true" ]]; then
         # Get last restart timestamp directly before instance-admin call to verify restart after
         TIMESTAMP=$(curl -s --anyauth "http://${HOSTNAME}:8001/admin/v1/timestamp")
 
-        curl_retry_validate "http://${HOSTNAME}:8001/admin/v1/instance-admin" 202 "-o /dev/null -X POST \
-            -H \"Content-type:application/x-www-form-urlencoded; charset=utf-8\" -d \"${ML_ADMIN_USERNAME_PAYLOAD}\" \
-            --data-urlencode \"${ML_ADMIN_PASSWORD_PAYLOAD}\" -d \"${ML_REALM_PAYLOAD}\" --data-urlencode \"${ML_WALLET_PASSWORD_PAYLOAD}\""
+        curl_retry_validate true "http://${HOSTNAME}:8001/admin/v1/instance-admin" 202 \
+            "-o" "/dev/null" "-X" "POST" "-H" "Content-type:application/x-www-form-urlencoded; charset=utf-8" "-d" "${ML_ADMIN_USERNAME_PAYLOAD}" "--data-urlencode" "${ML_ADMIN_PASSWORD_PAYLOAD}" "-d" "${ML_REALM_PAYLOAD}" "--data-urlencode" "${ML_WALLET_PASSWORD_PAYLOAD}"
 
         restart_check "${HOSTNAME}" "${TIMESTAMP}"
     fi
@@ -437,32 +432,29 @@ elif [[ "${MARKLOGIC_JOIN_CLUSTER}" == "true" ]]; then
         info "MARKLOGIC_JOIN_CLUSTER is true and join conditions are met, joining host to the cluster."
         if [[ -z "${MARKLOGIC_GROUP}" ]]; then
             info "MARKLOGIC_GROUP is not specified, adding host to the Default group."
-            MARKLOGIC_GROUP_PAYLOAD=\"group=Default\"
+            MARKLOGIC_GROUP_PAYLOAD="group=Default"
         else
-            curl_retry_validate "${ML_BOOTSTRAP_PROTOCOL}://${MARKLOGIC_BOOTSTRAP_HOST}:8002/manage/v2/groups/${MARKLOGIC_GROUP}" 200 "-X GET -o /dev/null --anyauth --user \"${ML_ADMIN_USERNAME}\":\"${ML_ADMIN_PASSWORD}\" --cacert \"${ML_CACERT_FILE}\"" false
+            curl_retry_validate false "${ML_BOOTSTRAP_PROTOCOL}://${MARKLOGIC_BOOTSTRAP_HOST}:8002/manage/v2/groups/${MARKLOGIC_GROUP}" 200 \
+                "-X" "GET" "-o" "/dev/null" "--anyauth" "--user" "${ML_ADMIN_USERNAME}:${ML_ADMIN_PASSWORD}" "--cacert" "${ML_CACERT_FILE}"
             GROUP_RESP_CODE=$?
             if [[ ${GROUP_RESP_CODE} -eq 200 ]]; then
                 info "MARKLOGIC_GROUP is specified, adding host to the ${MARKLOGIC_GROUP} group."
-                MARKLOGIC_GROUP_PAYLOAD=\"group=${MARKLOGIC_GROUP}\"
+                MARKLOGIC_GROUP_PAYLOAD="group=${MARKLOGIC_GROUP}"
             else
                 error "MARKLOGIC_GROUP ${MARKLOGIC_GROUP} does not exist on the cluster" exit
             fi
         fi
-        curl_retry_validate "http://${HOSTNAME}:8001/admin/v1/server-config" 200 "--anyauth --user \"${ML_ADMIN_USERNAME}\":\"${ML_ADMIN_PASSWORD}\" \
-            -o host.xml -X GET -H \"Accept: application/xml\""
+        curl_retry_validate true "http://${HOSTNAME}:8001/admin/v1/server-config" 200 \
+            "--anyauth" "--user" "${ML_ADMIN_USERNAME}:${ML_ADMIN_PASSWORD}" "-o" "host.xml" "-X" "GET" "-H" "Accept: application/xml"
 
-        curl_retry_validate "${ML_BOOTSTRAP_PROTOCOL}://${MARKLOGIC_BOOTSTRAP_HOST}:8001/admin/v1/cluster-config" 200 "--anyauth --user \"${ML_ADMIN_USERNAME}\":\"${ML_ADMIN_PASSWORD}\" \
-            -X POST -d \"${MARKLOGIC_GROUP_PAYLOAD}\" \
-            --data-urlencode \"server-config@./host.xml\" \
-            -H \"Content-type: application/x-www-form-urlencoded\" \
-            -o cluster.zip --cacert \"${ML_CACERT_FILE}\""
+        curl_retry_validate true "${ML_BOOTSTRAP_PROTOCOL}://${MARKLOGIC_BOOTSTRAP_HOST}:8001/admin/v1/cluster-config" 200 \
+            "--anyauth" "--user" "${ML_ADMIN_USERNAME}:${ML_ADMIN_PASSWORD}" "-X" "POST" "-d" "${MARKLOGIC_GROUP_PAYLOAD}" "--data-urlencode" "server-config@./host.xml" "-H" "Content-type: application/x-www-form-urlencoded" "-o" "cluster.zip" "--cacert" "${ML_CACERT_FILE}"
 
         # Get last restart timestamp directly before cluster-config call to verify restart after
         TIMESTAMP=$(curl -s --anyauth "http://${HOSTNAME}:8001/admin/v1/timestamp")
 
-        curl_retry_validate "http://${HOSTNAME}:8001/admin/v1/cluster-config" 202 "-o /dev/null --anyauth --user \"${ML_ADMIN_USERNAME}\":\"${ML_ADMIN_PASSWORD}\" \
-            -X POST -H \"Content-type: application/zip\" \
-            --data-binary @./cluster.zip"
+        curl_retry_validate true "http://${HOSTNAME}:8001/admin/v1/cluster-config" 202 \
+            "-o" "/dev/null" "--anyauth" "--user" "${ML_ADMIN_USERNAME}:${ML_ADMIN_PASSWORD}" "-X" "POST" "-H" "Content-type: application/zip" "--data-binary" "@./cluster.zip"
     
         restart_check "${HOSTNAME}" "${TIMESTAMP}"
 

--- a/test/compose-test-1.yaml
+++ b/test/compose-test-1.yaml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
     bootstrap_3n:
-      image: marklogic-centos/marklogic-server-centos:11-746
+      image: marklogicdb/marklogic-db
       container_name: bootstrap_3n
       hostname: bootstrap_3n
       dns_search: ""

--- a/test/compose-test-10.yaml
+++ b/test/compose-test-10.yaml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
     node2:
-      image: marklogic-centos/marklogic-server-centos:11-746
+      image: marklogicdb/marklogic-db
       container_name: node2
       hostname: node2
       dns_search: ""

--- a/test/compose-test-11.yaml
+++ b/test/compose-test-11.yaml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
     node3:
-      image: marklogic-centos/marklogic-server-centos:11-746
+      image: marklogicdb/marklogic-db
       container_name: node3
       hostname: node3
       dns_search: ""

--- a/test/compose-test-12.yaml
+++ b/test/compose-test-12.yaml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
     bootstrap_3n:
-      image: marklogic-centos/marklogic-server-centos:11-746
+      image: marklogicdb/marklogic-db
       container_name: bootstrap_3n
       hostname: bootstrap_3n
       dns_search: ""

--- a/test/compose-test-13.yaml
+++ b/test/compose-test-13.yaml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
     node2:
-      image: marklogic-centos/marklogic-server-centos:11-746
+      image: marklogicdb/marklogic-db
       container_name: node2
       hostname: node2
       dns_search: ""

--- a/test/compose-test-14.yaml
+++ b/test/compose-test-14.yaml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
     bootstrap_3n:
-      image: marklogic-centos/marklogic-server-centos:11-746
+      image: marklogicdb/marklogic-db
       container_name: bootstrap_3n
       hostname: bootstrap_3n
       dns_search: ""

--- a/test/compose-test-15.yaml
+++ b/test/compose-test-15.yaml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
     node2:
-      image: marklogic-centos/marklogic-server-centos:11-746
+      image: marklogicdb/marklogic-db
       container_name: node2
       hostname: node2
       dns_search: ""

--- a/test/compose-test-2.yaml
+++ b/test/compose-test-2.yaml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
     node2:
-      image: marklogic-centos/marklogic-server-centos:11-746
+      image: marklogicdb/marklogic-db
       container_name: node2
       hostname: node2
       dns_search: ""

--- a/test/compose-test-3.yaml
+++ b/test/compose-test-3.yaml
@@ -2,7 +2,7 @@
 version: '3.6'
 services:
     bootstrap:
-      image: marklogic-centos/marklogic-server-centos:10-internal
+      image: marklogicdb/marklogic-db
       hostname: bootstrap
       container_name: bootstrap
       dns_search: ""
@@ -19,7 +19,7 @@ services:
       networks:
       - external_net
     node2:
-      image: marklogic-centos/marklogic-server-centos:10-internal
+      image: marklogicdb/marklogic-db
       hostname: node2
       container_name: node2
       dns_search: ""

--- a/test/compose-test-4.yaml
+++ b/test/compose-test-4.yaml
@@ -2,7 +2,7 @@
 version: '3.6'
 services:
     testbootstrap:
-      image: marklogic-centos/marklogic-server-centos:10-internal
+      image: marklogicdb/marklogic-db
       hostname: testbootstrap
       container_name: testbootstrap
       dns_search: ""
@@ -19,7 +19,7 @@ services:
       networks:
       - external_net
     testnode:
-      image: marklogic-centos/marklogic-server-centos:10-internal
+      image: marklogicdb/marklogic-db
       hostname: testnode
       container_name: testnode
       dns_search: ""
@@ -36,7 +36,7 @@ services:
         - 7200-7210:8000-8010
         - 7297:7997
       depends_on:
-      - bootstrap
+      - testbootstrap
       networks:
       - external_net
 networks:

--- a/test/compose-test-5.yaml
+++ b/test/compose-test-5.yaml
@@ -2,7 +2,7 @@
 version: '3.6'
 services:
     testbootstrap:
-      image: marklogic-centos/marklogic-server-centos:10-internal
+      image: marklogicdb/marklogic-db
       hostname: testbootstrap
       container_name: testbootstrap
       dns_search: ""
@@ -19,7 +19,7 @@ services:
       networks:
       - external_net
     testnode:
-      image: marklogic-centos/marklogic-server-centos:10-internal
+      image: marklogicdb/marklogic-db
       hostname: testnode
       container_name: testnode
       dns_search: ""
@@ -36,7 +36,7 @@ services:
         - 7200-7210:8000-8010
         - 7297:7997
       depends_on:
-      - bootstrap
+      - testbootstrap
       networks:
       - external_net
 networks:

--- a/test/compose-test-6.yaml
+++ b/test/compose-test-6.yaml
@@ -2,7 +2,7 @@
 version: '3.6'
 services:
   bootstrap_2n:
-      image: marklogic-centos/marklogic-server-centos:20210909
+      image: marklogicdb/marklogic-db
       hostname: bootstrap_2n
       container_name: bootstrap_2n
       dns_search: ""

--- a/test/compose-test-7.yaml
+++ b/test/compose-test-7.yaml
@@ -2,7 +2,7 @@
 version: '3.6'
 services:
     node2:
-      image: marklogic-centos/marklogic-server-centos:20210909
+      image: marklogicdb/marklogic-db
       container_name: node2
       hostname: node2
       dns_search: ""
@@ -22,8 +22,6 @@ services:
       ports:
         - 7200-7210:8000-8010
         - 7297:7997
-      depends_on:
-      - bootstrap_2n
       networks:
       - external_net
 secrets:

--- a/test/compose-test-8.yaml
+++ b/test/compose-test-8.yaml
@@ -2,7 +2,7 @@
 version: '3.6'
 services:
     bootstrap:
-      image: marklogic-centos/marklogic-server-centos:10-internal
+      image: marklogicdb/marklogic-db
       hostname: bootstrap
       container_name: bootstrap
       dns_search: ""

--- a/test/compose-test-9.yaml
+++ b/test/compose-test-9.yaml
@@ -2,7 +2,7 @@
 version: '3.6'
 services:
     bootstrap:
-      image: marklogic-centos/marklogic-server-centos:10-internal
+      image: marklogicdb/marklogic-db
       hostname: bootstrap
       container_name: bootstrap
       dns_search: ""
@@ -19,7 +19,7 @@ services:
       networks:
       - external_net
     node2:
-      image: marklogic-centos/marklogic-server-centos:10-internal
+      image: marklogicdb/marklogic-db
       hostname: node2
       container_name: node2
       dns_search: ""

--- a/test/docker-tests.robot
+++ b/test/docker-tests.robot
@@ -178,7 +178,8 @@ Two node compose example with node joining enode group
   Verify response for authenticated request with  7101  *No license key has been entered*
   Verify response for authenticated request with  7102  *Monitoring Dashboard*
   Add group enode on host on port 7102
-  Start compose from  ./compose-test-7.yaml
+  Start compose from  ./compose-test-7.yaml  readiness=False
+  Compose logs should contain  ./compose-test-7.yaml  *Cluster config complete, marking this container as ready.*
   Host node2 should be part of group enode
   [Teardown]  Run keywords  
   ...  Delete compose from  ./compose-test-6.yaml
@@ -198,7 +199,6 @@ Compose example with node joining cluster using https and missing certificate pa
 
 Two node compose example with bootstrap node without SSL enabled and node joining cluster using https 
   Start compose from  ./compose-test-12.yaml
-  Compose logs should contain  ./compose-test-12.yaml  *Cluster config complete, marking this container as ready.*
   Verify response for unauthenticated request with  7101  *Unauthorized*
   Verify response for unauthenticated request with  7101  *Unauthorized*
   Verify response for unauthenticated request with  7102  *Unauthorized*
@@ -206,7 +206,7 @@ Two node compose example with bootstrap node without SSL enabled and node joinin
   Verify response for authenticated request with  7101  *No license key has been entered*
   Verify response for authenticated request with  7102  *Monitoring Dashboard*
   Create invalid certificate file
-  Start compose from  ./compose-test-13.yaml
+  Start compose from  ./compose-test-13.yaml  readiness=False
   Compose logs should contain  ./compose-test-13.yaml  *TLS is not enabled on bootstrap_host_name host, please verify the configuration. Container shutting down.*
   [Teardown]  Run keywords  
   ...  Delete compose from  ./compose-test-12.yaml
@@ -214,7 +214,6 @@ Two node compose example with bootstrap node without SSL enabled and node joinin
 
 Two node compose example with node joining cluster using invalid CAcertificate
   Start compose from  ./compose-test-14.yaml
-  Compose logs should contain  ./compose-test-14.yaml  *Cluster config complete, marking this container as ready.*
   Verify response for unauthenticated request with  7101  *Unauthorized*
   Verify response for authenticated request with  7101  *No license key has been entered*
   Add certificate template on bootstrap host  ./test_template.json  7102
@@ -222,7 +221,7 @@ Two node compose example with node joining cluster using invalid CAcertificate
   Apply certificate testTemplate on App Server Admin 7102
   Apply certificate testTemplate on App Server Manage 7102
   Create invalid certificate file
-  Start compose from  ./compose-test-15.yaml
+  Start compose from  ./compose-test-15.yaml  readiness=False
   Compose logs should contain  ./compose-test-15.yaml  *MARKLOGIC_JOIN_CACERT_FILE is not valid, please check above error for details. Node shutting down.*
   [Teardown]  Run keywords  
   ...  Delete compose from  ./compose-test-14.yaml
@@ -230,14 +229,13 @@ Two node compose example with node joining cluster using invalid CAcertificate
 
 Two node compose example with node joining cluster using https
   Start compose from  ./compose-test-1.yaml
-  Compose logs should contain  ./compose-test-1.yaml  *Cluster config complete, marking this container as ready.*
   Verify response for unauthenticated request with  7101  *Unauthorized*
   Verify response for authenticated request with  7101  *No license key has been entered*
   Add certificate template on bootstrap host  ./test_template.json  7102
   Get CAcertificate for testTemplate 7100
   Apply certificate testTemplate on App Server Admin 7102
   Apply certificate testTemplate on App Server Manage 7102
-  Start compose from  ./compose-test-2.yaml
+  Start compose from  ./compose-test-2.yaml  readiness=False
   Compose logs should contain  ./compose-test-2.yaml  *Cluster config complete, marking this container as ready.*
   [Teardown]  Run keywords  
   ...  Delete compose from  ./compose-test-1.yaml
@@ -245,7 +243,6 @@ Two node compose example with node joining cluster using https
 
 Single node compose example with bootstrap node joining trying to itself
   Start compose from  ./compose-test-8.yaml
-  Compose logs should contain  ./compose-test-8.yaml  *Cluster config complete, marking this container as ready.*
   Verify response for unauthenticated request with  7100  *Unauthorized*
   Verify response for unauthenticated request with  7101  *Unauthorized*
   Verify response for unauthenticated request with  7102  *Unauthorized*

--- a/test/keywords.resource
+++ b/test/keywords.resource
@@ -73,6 +73,7 @@ Start compose from
   IF  ${readiness} == True
     ${result}=  Run Process  docker  compose  -f  ${new path}  ps  --services
     @{nodes}=  Split to lines  ${result.stdout}
+    IF  @{nodes} == []  Fail  No containers detected in ${new path}!
     FOR    ${node}    IN    @{nodes}
       ${node}=   Get Variable Value  ${node}
       Compose logs should contain  ${new path}  *${node}*Cluster config complete, marking this container as ready.*


### PR DESCRIPTION
### Description
Remove eval call from curl_retry_validate function in order to prevent unintended shell expansion and increase general script safety. Argument order had to be updated and all reference to this function were updated as a consequence.
This PR also contains fixes to some of the cluster tests. It seems that some tests would pass when in fact they should've been failing. Finally, address linter errors.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
