### PR TITLE
DEVO-860 bug fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ import groovy.json.JsonSlurperClassic
 emailList = 'vitaly.korolev@progress.com, Barkha.Choithani@progress.com, Fayez.Saliba@progress.com, Sumanth.Ravipati@progress.com, Peng.Zhou@progress.com'
 // email list for security vulnerabilities only
 emailSecList = 'Rangan.Doreswamy@progress.com, Mahalakshmi.Srinivasan@progress.com'
-gitCredID = 'marklogic-builder'
+gitCredID = 'marklogic-builder-github'
 dockerRegistry = 'ml-docker-db-dev-tierpoint.bed-artifactory.bedford.progress.com'
 JIRA_ID_PATTERN = /(?i)(CLD|DEVO|QAINF|BUG|DBI)-\d{3,4}/
 JIRA_ID = ''


### PR DESCRIPTION
This PR fixes incorrect credentials label for github. The issue is only exposed when there is a PR job and we didn't have such case on the initial check in. Kubernetes pipeline already has the fix thanks to Peng.