### PR TITLE
MLE-12406: add docker rm for any leftover containers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -329,6 +329,7 @@ pipeline {
             sh '''
                 cd src/centos
                 rm -rf *.rpm
+                docker rm -f $(docker ps -a -q) || true
                 docker system prune --force --filter "until=720h"
                 docker volume prune --force
                 docker image prune --force --all


### PR DESCRIPTION
### Description
This is a quick fix to ensure we don't have failing jobs because of leftover containers.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
