### PR TITLE
MLE- 13690: Docker container gets stuck while upgrading from centos/ubi image to ubi-rootless and MLE-13692

### DIFF
--- a/src/scripts/start-marklogic-rootless.sh
+++ b/src/scripts/start-marklogic-rootless.sh
@@ -483,6 +483,10 @@ do
         info "Cluster config complete, marking this container as ready."
         rm -f host_health.xml
         break
+    elif [[ -f /var/opt/MarkLogic/DOCKER_INIT ]] && [ "${HOST_RESP_CODE}" -eq 200 ]; then
+        sudo touch /var/opt/MarkLogic/ready
+        info "Cluster config complete, marking this container as ready."
+        break
     else
         info "MarkLogic not ready yet, retrying."
         sleep 5

--- a/src/scripts/start-marklogic-rootless.sh
+++ b/src/scripts/start-marklogic-rootless.sh
@@ -484,7 +484,7 @@ do
         rm -f host_health.xml
         break
     elif [[ -f /var/opt/MarkLogic/DOCKER_INIT ]] && [ "${HOST_RESP_CODE}" -eq 200 ]; then
-        sudo touch /var/opt/MarkLogic/ready
+        touch /var/opt/MarkLogic/ready
         info "Cluster config complete, marking this container as ready."
         break
     else

--- a/src/scripts/start-marklogic.sh
+++ b/src/scripts/start-marklogic.sh
@@ -35,7 +35,7 @@ log () {
 ###############################################################
 # removing MarkLogic ready file and create it when 8001 is accessible on node
 ###############################################################
-rm -f /var/opt/MarkLogic/ready
+sudo rm -f /var/opt/MarkLogic/ready
 
 ###############################################################
 # Prepare script
@@ -507,6 +507,10 @@ do
         sudo touch /var/opt/MarkLogic/ready
         info "Cluster config complete, marking this container as ready."
         rm -f host_health.xml
+        break
+    elif [[ -f /var/opt/MarkLogic/DOCKER_INIT ]] && [ "${HOST_RESP_CODE}" -eq 200 ]; then
+        sudo touch /var/opt/MarkLogic/ready
+        info "Cluster config complete, marking this container as ready."
         break
     else
         info "MarkLogic not ready yet, retrying."


### PR DESCRIPTION
### Description
fix for the ml ready logging bug

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
