### PR TITLE
MLE-14180 converter install fix

### DIFF
--- a/src/scripts/start-marklogic-rootless.sh
+++ b/src/scripts/start-marklogic-rootless.sh
@@ -82,7 +82,7 @@ if [[ "${INSTALL_CONVERTERS}" == "true" ]]; then
         CONVERTERS_PATH="/tmp/converters.rpm"
         cd /tmp || exit
         rpm2cpio ${CONVERTERS_PATH} | cpio -ivd ./opt/*
-        mv /tmp/opt/MarkLogic/Converters /opt/MarkLogic/
+        cp -r /tmp/opt/MarkLogic/* /opt/MarkLogic/
         rm -rf /tmp/opt && rm -rf ${CONVERTERS_PATH}
     fi
 elif [[ -z "${INSTALL_CONVERTERS}" ]] || [[ "${INSTALL_CONVERTERS}" == "false" ]]; then


### PR DESCRIPTION
### Description
Converter files go directly to /opt/MarkLogic instead of a subdirectory there so the move command is replaced with copy and updated path.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
