### PR TITLE
MLE-15754 improve cleanup steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -377,11 +377,11 @@ pipeline {
         always {
             sh '''
                 cd src
-                rm -rf *.rpm
-                docker rm -f $(docker ps -a -q) || true
-                docker system prune --force --filter "until=720h"
-                docker volume prune --force
-                docker image prune --force --all
+                rm -rf *.rpm NOTICE.txt
+                docker stop $(docker ps -a -q) || true
+                docker system prune --force --all
+                docker volume prune --force --all
+                docker system df
             '''
             publishTestResults()
         }


### PR DESCRIPTION
### Description
Turns out docker build cache wasn't fully cleared which can result in inconsistent results.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
