### PR TITLE
MLE-16256 scap fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ endif
 	docker run -itd --name scap-scan -v $(PWD)/scap:/scap ${current_image}
 	docker exec -u root scap-scan /bin/bash -c "microdnf install -y openscap-scanner"
 	# ensure the file is owned by root in order to avoid permission issues
-	docker exec -u root scap-scan /bin/bash -c "chown root:root /scap/ssg-rhel8-ds.xml"
+	docker exec -u root scap-scan /bin/bash -c "chown root:root /scap/ssg-rhel-ds.xml"
 	docker exec -u root scap-scan /bin/bash -c "oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_cis --results /scap/scap_scan_results.xml --report /scap/scap_scan_report.html /scap/ssg-rhel-ds.xml > /scap/command-output.txt 2>&1" || true
 	docker rm -f scap-scan
 


### PR DESCRIPTION
### Description
PR contains two fixes for outstanding OpenSCAP scan issues:
- update file permission for a temporary file created for the scan in order to resolve 
xccdf_org.ssgproject.content_rule_file_permissions_ungroupowned
- skip xccdf_org.ssgproject.content_rule_enable_authselect rule as it's not applicable to UBI-minimal image.


#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
