### PR TITLE
MLE-16256 add cleanup step to resolve repeated run issue on jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ endif
 	# ensure the file is owned by root in order to avoid permission issues
 	docker exec -u root scap-scan /bin/bash -c "chown root:root /scap/ssg-rhel-ds.xml"
 	docker exec -u root scap-scan /bin/bash -c "oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_cis --results /scap/scap_scan_results.xml --report /scap/scap_scan_report.html /scap/ssg-rhel-ds.xml > /scap/command-output.txt 2>&1" || true
+	docker exec -u root scap-scan /bin/bash -c "rm -f /scap/ssg-rhel-ds.xml"
 	docker rm -f scap-scan
 
 #***************************************************************************


### PR DESCRIPTION
Turns out leaving files owned by root can be problematic. This PR cleans up the temporary file that get root ownership.