### PR TITLE
MLE-18005 disable ubi9 on 12

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -346,9 +346,7 @@ pipeline {
                                                              30 02 * * * % marklogicVersion=12;dockerImageType=ubi
                                                              30 02 * * * % marklogicVersion=12;dockerImageType=ubi-rootless;SCAP_SCAN=true
                                                              00 03 * * * % marklogicVersion=11;dockerImageType=ubi9
-                                                             00 03 * * * % marklogicVersion=11;dockerImageType=ubi9-rootless;SCAP_SCAN=true
-                                                             00 03 * * * % marklogicVersion=12;dockerImageType=ubi9
-                                                             00 03 * * * % marklogicVersion=12;dockerImageType=ubi9-rootless;SCAP_SCAN=true''' : '')
+                                                             00 03 * * * % marklogicVersion=11;dockerImageType=ubi9-rootless;SCAP_SCAN=true''' : '')
     }
     environment {
         QA_LICENSE_KEY = credentials('QA_LICENSE_KEY')


### PR DESCRIPTION
### Description
- We have enabled UBI9 builds for MarkLogic 12 too early. The RPM are not published yet and the builds are failing because of this.
- Also add `docker logout` to make sure we use fresh login token every time.
- Simplify clean up a bit.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
