### PR TITLE
MLE-21703 remove package update in ubi9 and refresh ubi8

### DIFF
--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -4,15 +4,16 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1745855087
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1747111267
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 ###############################################################
 # install libnsl rpm package
 ###############################################################
 
-RUN microdnf -y update \
-    && curl -Lso libnsl.rpm https://bed-artifactory.bedford.progress.com:443/artifactory/ml-rpm-release-tierpoint/devdependencies/libnsl-2.34-125.el9_5.8.x86_64.rpm \
+# Disabled update to avoid issues with libnsl package version (MLE-21703)
+# RUN microdnf -y update \
+RUN curl -Lso libnsl.rpm https://bed-artifactory.bedford.progress.com:443/artifactory/ml-rpm-release-tierpoint/devdependencies/libnsl-2.34-125.el9_5.8.x86_64.rpm \
     && rpm -i libnsl.rpm \
     && rm -f libnsl.rpm
 

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741795396
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1255
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 ###############################################################


### PR DESCRIPTION
### Description
Update UBI9 base image to the latest 9.5 and disable general `microdnf update` to avoid dependency issue with libnsl.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
