### PR TITLE
MLE-21289,MLE-21290,MLE-21291,MLE-21292: update dynamic hosts tests due to the refactor of the cluster token based authentication mechanism.

### DIFF
--- a/test/docker-tests.robot
+++ b/test/docker-tests.robot
@@ -568,6 +568,7 @@ Dynamic Host Cluster Test
     Sleep    60s
     ${group}=    set Variable    dynamic
     Set up dynamic host group ${group}
+    Enable API token authentication on 7202 for group Default
     Dynamic Host Join Successful on ${group} with 7401
     Dynamic Host Join Failure on dynamic with 7501 with wrong token
     Dynamic Host Join Failure on dynamic with 7501 when feature disabled
@@ -598,6 +599,7 @@ Dynamic Host Cluster Concurrecy Join Test
     Sleep    60s
     ${group}=    set Variable    dynamic
     Set up dynamic host group ${group}
+    Enable API token authentication on 7202 for group Default
     Concurrent Dynamic Host Join Test
 
     [Teardown]    Delete compose from    compose-test-16.yaml

--- a/test/keywords.resource
+++ b/test/keywords.resource
@@ -368,6 +368,15 @@ Enable dynamic host feature on ${dockerport} for group ${group}
     ${response}=    PUT On Session    RestSession    url=/manage/v2/groups/${group}/properties?format=json    json=${json_body}    headers=${header}
     RETURN    ${response}
 
+Enable API token authentication on ${dockerport} for group ${group}
+    [Documentation]    This enables the API token authentication for the specified group
+    ${auth}    ${headers}=    Generate digest authorization for    ${DEFAULT ADMIN USER}    ${DEFAULT ADMIN PASS}
+    ${header}=    Create Dictionary    Content-type=application/json    Accept=application/json
+    ${json_body}=    Create Dictionary    API-token-authentication=${TRUE}
+    ${response}=    Create Digest Session    RestSession    url=http://localhost:${dockerport}    headers=${headers}    auth=${auth}
+    ${response}=    PUT On Session    RestSession    url=/manage/v2/servers/Admin/properties?group-id=${group}    json=${json_body}    headers=${header}
+    RETURN    ${response}
+
 Disable dynamic host feature on ${dockerport} for group ${group}
     [Documentation]    This enables the dynamic host feature for the specified group.
     ${auth}    ${headers}=    Generate digest authorization for    ${DEFAULT ADMIN USER}    ${DEFAULT ADMIN PASS}
@@ -398,8 +407,6 @@ Create group ${group} on port ${port}
 
 Set up dynamic host group ${group}
     Create group ${group} on port 7102
-    # TODO: the enabling of the option on the Default group should be removed once the bug is fixed.
-    Enable dynamic host feature on 7102 for group Default
     Enable dynamic host feature on 7102 for group ${group}
 
 Get MarkLogic Host ID on port ${port} with hostname ${hostname}


### PR DESCRIPTION
Hi Team,

I am updating the tests for the dynamic hosts due to some refactor work. Can you take a look and merge the PR if things look good to you?

Best regards,
Yunjian