### PR TITLE
MLE-21703 zlib workaround

### DIFF
--- a/dockerFiles/marklogic-server-ubi-rootless:base
+++ b/dockerFiles/marklogic-server-ubi-rootless:base
@@ -119,7 +119,9 @@ ENV MARKLOGIC_INSTALL_DIR=/opt/MarkLogic  \
     BUILD_BRANCH=${BUILD_BRANCH} \
     MARKLOGIC_JOIN_TLS_ENABLED=false \
     MARKLOGIC_EC2_HOST=0 \
-    TZ=UTC
+    TZ=UTC \
+    WITH_SYSTEM_ZLIB=FALSE
+    # set WITH_SYSTEM_ZLIB for CVE-2025-4638 workaround
 
 ################################################################
 # Set Timezone

--- a/dockerFiles/marklogic-server-ubi:base
+++ b/dockerFiles/marklogic-server-ubi:base
@@ -105,7 +105,9 @@ ENV MARKLOGIC_INSTALL_DIR=/opt/MarkLogic  \
     BUILD_BRANCH=${BUILD_BRANCH} \
     MARKLOGIC_JOIN_TLS_ENABLED=false \
     OVERWRITE_ML_CONF=true \
-    MARKLOGIC_EC2_HOST=0
+    MARKLOGIC_EC2_HOST=0 \
+    WITH_SYSTEM_ZLIB=FALSE
+    # set WITH_SYSTEM_ZLIB for CVE-2025-4638 workaround
     
 ################################################################
 # Set Timezone


### PR DESCRIPTION
### Description
Add WITH_SYSTEM_ZLIB=FALSE as a workaround for CVE-2025-4638

#### Checklist: 

-  ##### Owner:

- [X] JIRA_ID as part of branch/PR name
- [X] Rebase the branch with upstream
- [X] Squashed all commits into a single commit
- [X] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
