### PR TITLE
MLE-21703 remove zlib vulnerability workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -1076,7 +1076,6 @@ Where is calculated as described in the [Configuring HugePages](https://github.c
     - libdb-utils (CVE-2016-0682, CVE-2016-0689, CVE-2016-0692, CVE-2016-0694, CVE-2016-3418, CVE-2017-3604, CVE-2017-3605, CVE-2017-3606, CVE-2017-3607, CVE-2017-3608, CVE-2017-3609, CVE-2017-3610, CVE-2017-3611, CVE-2017-3612, CVE-2017-3613, CVE-2017-3614, CVE-2017-3615
 CVE-2017-3616, CVE-2017-3617)
     - nspr (CVE-2016-1951)
-    - zlib (CVE-2025-4638)
 
 These packages are included in the RedHat UBI base images but, to-date, no fixes have been made available. Even though these libraries may be present in the base image that is used by MarkLogic Server, they are not used by MarkLogic Server itself, hence there is no impact or mitigation required.
 

--- a/dockerFiles/marklogic-server-ubi-rootless:base
+++ b/dockerFiles/marklogic-server-ubi-rootless:base
@@ -119,9 +119,7 @@ ENV MARKLOGIC_INSTALL_DIR=/opt/MarkLogic  \
     BUILD_BRANCH=${BUILD_BRANCH} \
     MARKLOGIC_JOIN_TLS_ENABLED=false \
     MARKLOGIC_EC2_HOST=0 \
-    TZ=UTC \
-    WITH_SYSTEM_ZLIB=FALSE
-    # set WITH_SYSTEM_ZLIB for CVE-2025-4638 workaround
+    TZ=UTC
 
 ################################################################
 # Set Timezone

--- a/dockerFiles/marklogic-server-ubi:base
+++ b/dockerFiles/marklogic-server-ubi:base
@@ -105,9 +105,7 @@ ENV MARKLOGIC_INSTALL_DIR=/opt/MarkLogic  \
     BUILD_BRANCH=${BUILD_BRANCH} \
     MARKLOGIC_JOIN_TLS_ENABLED=false \
     OVERWRITE_ML_CONF=true \
-    MARKLOGIC_EC2_HOST=0 \
-    WITH_SYSTEM_ZLIB=FALSE
-    # set WITH_SYSTEM_ZLIB for CVE-2025-4638 workaround
+    MARKLOGIC_EC2_HOST=0
     
 ################################################################
 # Set Timezone


### PR DESCRIPTION
### Description
zlib vulnerability was removed from the base image so we don't need the README statement or the workaround.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
