### PR TITLE
MLE-22761 docker init fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -465,7 +465,7 @@ pipeline {
         booleanParam(name: 'PUBLISH_IMAGE', defaultValue: false, description: 'Publish image to internal registry')
         booleanParam(name: 'TEST_STRUCTURE', defaultValue: true, description: 'Run container structure tests')
     booleanParam(name: 'DOCKER_TESTS', defaultValue: true, description: 'Run docker tests')
-    string(name: 'DOCKER_TEST_LIST', defaultValue: '', description: 'Comma separated list of test names to run (e.g "Test one", "Test two"). Leave empty to run all tests.', trim: true)
+    string(name: 'DOCKER_TEST_LIST', defaultValue: '', description: 'Comma separated list of test names to run (e.g Test one, Test two). Leave empty to run all tests.', trim: true)
         booleanParam(name: 'SCAP_SCAN', defaultValue: false, description: 'Run Open SCAP scan on the image.')
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -280,7 +280,7 @@ void structureTests() {
  * Runs Docker functional tests using the 'make docker-tests' target.
  */
 void dockerTests() {
-    sh "make docker-tests current_image=marklogic/marklogic-server-${dockerImageType}:${marklogicVersion}-${env.dockerImageType}-${env.dockerVersion} upgrade_image=${upgradeDockerImage} marklogicVersion=${marklogicVersion} build_branch=${env.BRANCH_NAME} dockerVersion=${env.dockerVersion} docker_image_type=${dockerImageType}"
+    sh "make docker-tests current_image=marklogic/marklogic-server-${dockerImageType}:${marklogicVersion}-${env.dockerImageType}-${env.dockerVersion} upgrade_image=${upgradeDockerImage} marklogicVersion=${marklogicVersion} build_branch=${env.BRANCH_NAME} dockerVersion=${env.dockerVersion} docker_image_type=${dockerImageType} DOCKER_TEST_LIST=\"${params.DOCKER_TEST_LIST}\""
 }
 
 /**
@@ -445,7 +445,10 @@ pipeline {
                                                              00 03 * * * % marklogicVersion=11;dockerImageType=ubi9
                                                              00 03 * * * % marklogicVersion=11;dockerImageType=ubi9-rootless;SCAP_SCAN=true
                                                              00 03 * * * % marklogicVersion=12;dockerImageType=ubi9
-                                                             30 03 * * * % marklogicVersion=12;dockerImageType=ubi9-rootless;SCAP_SCAN=true''' : '')
+                                                             30 03 * * * % marklogicVersion=12;dockerImageType=ubi9-rootless;SCAP_SCAN=true
+                                                             00 05 * * 7 % marklogicVersion=10;dockerImageType=ubi;DOCKER_TEST_LIST="Initialized MarkLogic container with latency"
+                                                             30 05 * * 7 % marklogicVersion=11;dockerImageType=ubi;DOCKER_TEST_LIST="Initialized MarkLogic container with latency"
+                                                             00 06 * * 7 % marklogicVersion=12;dockerImageType=ubi;DOCKER_TEST_LIST="Initialized MarkLogic container with latency"''' : '')
     }
     environment {
         QA_LICENSE_KEY = credentials('QA_LICENSE_KEY')
@@ -461,7 +464,8 @@ pipeline {
         string(name: 'ML_CONVERTERS', defaultValue: '', description: 'URL for the converters RPM to be included in the image creation \n If left blank the nightly ML Converters Package will be used.', trim: true)
         booleanParam(name: 'PUBLISH_IMAGE', defaultValue: false, description: 'Publish image to internal registry')
         booleanParam(name: 'TEST_STRUCTURE', defaultValue: true, description: 'Run container structure tests')
-        booleanParam(name: 'DOCKER_TESTS', defaultValue: true, description: 'Run docker tests')
+    booleanParam(name: 'DOCKER_TESTS', defaultValue: true, description: 'Run docker tests')
+    string(name: 'DOCKER_TEST_LIST', defaultValue: '', description: 'Comma separated list of test names to run (e.g "Test one", "Test two"). Leave empty to run all tests.', trim: true)
         booleanParam(name: 'SCAP_SCAN', defaultValue: false, description: 'Run Open SCAP scan on the image.')
     }
 

--- a/src/scripts/start-marklogic.sh
+++ b/src/scripts/start-marklogic.sh
@@ -116,8 +116,12 @@ if [[ -n "${TZ}" ]]; then
     echo "${TZ}" | sudo tee /etc/timezone
 fi
 
-N_RETRY=5
+# N_RETRY: Number of retries for failed operations (default: 5)  
+N_RETRY=${N_RETRY:-15}
+# RETRY_INTERVAL: Interval in seconds between retries (default: 10)
 RETRY_INTERVAL=10
+# CURL_TIMEOUT: Timeout in seconds for curl commands (default: 300)
+CURL_TIMEOUT=${CURL_TIMEOUT:-300}
 
 ################################################################
 # restart_check(hostname, baseline_timestamp)
@@ -133,15 +137,15 @@ RETRY_INTERVAL=10
 function restart_check {
     info "Waiting for MarkLogic to restart."
     local retry_count LAST_START
-    LAST_START=$(curl -s --anyauth --user "${ML_ADMIN_USERNAME}":"${ML_ADMIN_PASSWORD}" "http://$1:8001/admin/v1/timestamp")
+    LAST_START=$(curl -s -m "${CURL_TIMEOUT}" --anyauth --user "${ML_ADMIN_USERNAME}":"${ML_ADMIN_PASSWORD}" "http://$1:8001/admin/v1/timestamp")
     for ((retry_count = 0; retry_count < N_RETRY; retry_count = retry_count + 1)); do
         if [[ "$2" == "${LAST_START}" ]] || [[ -z "${LAST_START}" ]]; then
             sleep ${RETRY_INTERVAL}
-            LAST_START=$(curl -s --anyauth --user "${ML_ADMIN_USERNAME}":"${ML_ADMIN_PASSWORD}" "http://$1:8001/admin/v1/timestamp")
+            LAST_START=$(curl -s -m "${CURL_TIMEOUT}" --anyauth --user "${ML_ADMIN_USERNAME}":"${ML_ADMIN_PASSWORD}" "http://$1:8001/admin/v1/timestamp")
         else
             info "MarkLogic has restarted."
-            return 0
-        fi
+                    return 0
+                fi
     done
     error "Failed to restart $1" exit
 }
@@ -194,7 +198,7 @@ function validate_cert {
     local cacertfile=$1
     local return_code
     local curl_output
-    curl_output=$(curl -s -S -L --cacert "${cacertfile}" --ssl "${ML_BOOTSTRAP_PROTOCOL}"://"${MARKLOGIC_BOOTSTRAP_HOST}":8001 --anyauth --user "${ML_ADMIN_USERNAME}":"${ML_ADMIN_PASSWORD}")
+    curl_output=$(curl -s -S -L -m "${CURL_TIMEOUT}" --cacert "${cacertfile}" --ssl "${ML_BOOTSTRAP_PROTOCOL}"://"${MARKLOGIC_BOOTSTRAP_HOST}":8001 --anyauth --user "${ML_ADMIN_USERNAME}":"${ML_ADMIN_PASSWORD}")
     return_code=$?
     if [[ $return_code != "0" ]]; then
         info "$curl_output"
@@ -209,6 +213,8 @@ function validate_cert {
 # Use RETRY_INTERVAL to tune the test length.
 # Validate that response code is the same as expected response
 # code or exit with an error.
+# NOTE: /admin/v1/instance-admin is NOT idempotent; call it exactly once
+# and do not retry.
 #
 #   $1 :  Flag indicating if the script should exit if the given response code is not received ("true" to exit, "false" to return the response code")
 #   $2 :  The target url to test against
@@ -222,9 +228,26 @@ function curl_retry_validate {
     local expected_response_code=$1; shift
     local curl_options=("$@")
 
+    # Special case: instance-admin must only be invoked once (non-idempotent)
+    if [[ "${endpoint}" == *"/admin/v1/instance-admin"* ]]; then
+        response=$(curl -s -m "${CURL_TIMEOUT}" -w '%{http_code}' "${curl_options[@]}" "$endpoint")
+        response_code=$(tail -n1 <<< "$response")
+        response_content=$(sed '$ d' <<< "$response")
+
+        if [[ ${response_code} -eq ${expected_response_code} ]]; then
+            return "${response_code}"
+        fi
+
+        echo "${response_content}" > start-marklogic_curl_retry_validate.log
+        if [[ "${return_error}" == "false" ]] ; then
+            return "${response_code}"
+        fi
+        [[ -f "start-marklogic_curl_retry_validate.log" ]] && cat start-marklogic_curl_retry_validate.log
+        error "Expected response code ${expected_response_code}, got ${response_code} from ${endpoint}." exit
+    fi
+
     for ((retry_count = 0; retry_count < N_RETRY; retry_count = retry_count + 1)); do
-        
-        response=$(curl -s -m 30 -w '%{http_code}' "${curl_options[@]}" "$endpoint")
+        response=$(curl -s -m "${CURL_TIMEOUT}" -w '%{http_code}' "${curl_options[@]}" "$endpoint")
         response_code=$(tail -n1 <<< "$response")
         response_content=$(sed '$ d' <<< "$response")
 
@@ -389,7 +412,7 @@ elif [[ "${MARKLOGIC_INIT}" == "true" ]]; then
     fi
 
     info "Initializing MarkLogic on ${HOSTNAME}"
-    TIMESTAMP=$(curl --anyauth -m 30 -s --retry 5 \
+    TIMESTAMP=$(curl --anyauth -m "${CURL_TIMEOUT}" -s --retry 5 \
         -i -X POST -H "Content-type:application/json" \
         -d "${LICENSE_PAYLOAD}" \
         http://"${HOSTNAME}":8001/admin/v1/init |

--- a/test/docker-tests.robot
+++ b/test/docker-tests.robot
@@ -91,6 +91,10 @@ Initialized MarkLogic container
 
 Initialized MarkLogic container with latency
     [Tags]    long_running
+    [Documentation]    This test verifies the initialization of the MarkLogic container with high latency.
+    ...                Setup on a linux host can be done with the following commands:
+    ...                sudo dnf install  kernel-modules-extra
+    ...                sudo modprobe sch_netem
     Skip If    '${IMAGE_TYPE}' != 'ubi'
     Create container with latency    -e    MARKLOGIC_INIT=true
     ...                      -e    MARKLOGIC_ADMIN_USERNAME=${DEFAULT ADMIN USER}

--- a/test/docker-tests.robot
+++ b/test/docker-tests.robot
@@ -89,6 +89,35 @@ Initialized MarkLogic container
     Verify response for authenticated request with    8002    *Monitoring Dashboard*
     [Teardown]    Delete container
 
+Initialized MarkLogic container with latency
+    [Tags]    long_running
+    Skip If    '${IMAGE_TYPE}' != 'ubi'
+    Create container with latency    -e    MARKLOGIC_INIT=true
+    ...                      -e    MARKLOGIC_ADMIN_USERNAME=${DEFAULT ADMIN USER}
+    ...                      -e    MARKLOGIC_ADMIN_PASSWORD=${DEFAULT ADMIN PASS}
+    IF    'rootless' not in '${IMAGE_TYPE}' # ROOT image
+        Docker log should contain    *OVERWRITE_ML_CONF is true, deleting existing /etc/marklogic.conf and overwriting with ENV variables.*
+    END
+    IF    'rootless' in '${IMAGE_TYPE}' # ROOTLESS image
+        Docker log should contain    */etc/marklogic.conf will be appended with provided environment variables.*
+    END
+    Docker log should contain    *MARKLOGIC_JOIN_CLUSTER is false or not defined, not joining cluster.*
+    Docker log should contain    *MARKLOGIC_INIT is true, initializing the MarkLogic server.*
+    Docker log should contain    *Starting container with MarkLogic Server.*
+    Docker log should contain    *| server ver: ${MARKLOGIC_VERSION} | scripts ver: ${MARKLOGIC_DOCKER_VERSION} | image type: ${IMAGE_TYPE} | branch: ${BUILD_BRANCH} |*
+    Docker log should contain    *Appended MARKLOGIC_PID_FILE to /etc/marklogic.conf*
+    Docker log should contain    *Appended MARKLOGIC_UMASK to /etc/marklogic.conf*
+    Docker log should contain    *Appended MARKLOGIC_USER to /etc/marklogic.conf*
+    Docker log should contain    *Appended MARKLOGIC_EC2_HOST to /etc/marklogic.conf*
+    Verify That marklogic.conf contains    MARKLOGIC_PID_FILE    MARKLOGIC_UMASK    MARKLOGIC_USER    MARKLOGIC_EC2_HOST=0
+    Verify response for unauthenticated request with    8000    *Unauthorized*
+    Verify response for unauthenticated request with    8001    *Unauthorized*
+    Verify response for unauthenticated request with    8002    *Unauthorized*
+    Verify response for authenticated request with    8000    *Query Console*
+    Verify response for authenticated request with    8001    *No license key has been entered*
+    Verify response for authenticated request with    8002    *Monitoring Dashboard*
+    [Teardown]    Delete container
+
 Upgrade MarkLogic container
     Skip If  'rootless' in '${IMAGE_TYPE}'  msg = Skipping Upgrade MarkLogic test for rootless image
     Create test container with    -e    MARKLOGIC_INIT=true
@@ -562,7 +591,7 @@ Initialized MarkLogic container with ML converters
 Dynamic Host Cluster Test
     [Tags]    dynamic-hosts
     ${major_version}=    Set Variable    ${MARKLOGIC_VERSION.split('.')[0]}
-    Skip If    ${major_version} < 12    msg=Dynamic Host Concurrency Test requires MarkLogic 12 or higher (current version: ${MARKLOGIC_VERSION})
+    Skip If    '${major_version}' == '' or '${major_version}' == 'None' or int('${major_version}' or '0') < 12    msg=Dynamic Host Concurrency Test requires MarkLogic 12 or higher (current version: ${MARKLOGIC_VERSION})
     Start compose from    compose-test-16.yaml
     # give it some time to prepare the large cluster
     Sleep    60s
@@ -593,7 +622,7 @@ Dynamic Host Cluster Test
 Dynamic Host Cluster Concurrecy Join Test
     [Tags]    dynamic-hosts
     ${major_version}=    Set Variable    ${MARKLOGIC_VERSION.split('.')[0]}
-    Skip If    ${major_version} < 12    msg=Dynamic Host Concurrency Test requires MarkLogic 12 or higher (current version: ${MARKLOGIC_VERSION})
+    Skip If    '${major_version}' == '' or '${major_version}' == 'None' or int('${major_version}' or '0') < 12    msg=Dynamic Host Concurrency Test requires MarkLogic 12 or higher (current version: ${MARKLOGIC_VERSION})
     Start compose from    compose-test-16.yaml
     # give it some time to prepare the large cluster
     Sleep    60s

--- a/test/keywords.resource
+++ b/test/keywords.resource
@@ -14,7 +14,7 @@ ${DEFAULT ADMIN PASS}    test_admin_pass
 ${SPEC CHARS ADMIN PASS}    Admin@2$s%^&*!
 ${TEST_IMAGE}    %{DOCKER_TEST_IMAGE=progressofficial/marklogic-db:11.3.1-ubi-rootless-2.2.0}
 ${UPGRADE_TEST_IMAGE}    progressofficial/marklogic-db:11.3.1-ubi-rootless-2.2.0
-${DOCKER TIMEOUT}    240s
+${DOCKER TIMEOUT}    300s
 ${LICENSE KEY}    %{QA_LICENSE_KEY=none}
 ${LICENSEE}    MarkLogic - Version 9 QA Test License
 ${MARKLOGIC_VERSION}    11.3.1
@@ -39,6 +39,24 @@ Create container with
     ...            timeout=${DOCKER TIMEOUT}
     File Should Be Empty    test_results/stderr-${container name}.txt
     Docker log should contain    *Cluster config complete, marking this container as ready.*
+
+Create container with latency
+    [Arguments]    @{input parameters}
+    [Documentation]    Use Docker run to create a single container with defined defaults and input parameters and simulated network latency.
+    ...                Container is named based on test case so that the same name can be used in cleanup.
+    ...                Also verifies that the container is up by checking Docker logs.
+    ${container name}=    Remove spaces from    ${TEST NAME}
+    Run Process    docker    run    @{DOCKER DEFAULTS}    @{input parameters}
+    ...            --name    ${container name}
+    ...            --cap-add    NET_ADMIN    --entrypoint    /bin/bash
+    ...            ${TEST_IMAGE}
+    ...            -c    sudo microdnf -y install iproute iptables && sudo curl -s -O https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/Packages/i/iproute-tc-6.2.0-6.el8_10.x86_64.rpm && sudo rpm -i iproute-tc-6.2.0-6.el8_10.x86_64.rpm && sudo tc qdisc add dev lo root netem delay 30000ms && sudo tc qdisc show dev lo && /tini -- /usr/local/bin/start-marklogic.sh
+    ...            stderr=test_results/stderr-${container name}.txt
+    ...            stdout=test_results/stdout-${container name}.txt
+    ...            timeout=15000
+    File Should Be Empty    test_results/stderr-${container name}.txt
+    Wait Until Keyword Succeeds    5 minutes    10s    Get container log message    *root refcnt 2 limit 1000 delay 30s*
+    Wait Until Keyword Succeeds    30 minutes    30s    Get container log message    *Cluster config complete, marking this container as ready.*
 
 Create failing container with
     [Arguments]    @{input parameters}


### PR DESCRIPTION
### Description
- Update startup script (root and rootless) to increase maximum curl timeout and to only call - /admin/v1/instance-admin endpoint once since it's idempotent.
- Add a test for high latency
- Add an option to the pipeline to run specific e2e test
- Schedule high latency test to run weekly on each version of MarkLogic

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
