### PR TITLE
MLE-23379 Add conditional ML10 dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 
 
 # build the image
-	cd src/; docker build ${docker_build_options} -t "${repo_dir}/marklogic-deps-${docker_image_type}:${dockerTag}" -f ../dockerFiles/marklogic-deps-${docker_image_type}:base .
+	cd src/; docker build ${docker_build_options} -t "${repo_dir}/marklogic-deps-${docker_image_type}:${dockerTag}" --build-arg ML_VERSION=${marklogicVersion} -f ../dockerFiles/marklogic-deps-${docker_image_type}:base .
 	cd src/; docker build ${docker_build_options} -t "${repo_dir}/marklogic-server-${docker_image_type}:${dockerTag}" --build-arg BASE_IMAGE=${repo_dir}/marklogic-deps-${docker_image_type}:${dockerTag} --build-arg ML_RPM=${package} --build-arg ML_USER=marklogic_user --build-arg ML_DOCKER_VERSION=${dockerVersion} --build-arg ML_VERSION=${marklogicVersion} --build-arg ML_CONVERTERS=${converters} --build-arg BUILD_BRANCH=${build_branch} --build-arg ML_DOCKER_TYPE=${docker_image_type} -f ../dockerFiles/marklogic-server-${docker_image_type}:base .
 
 # remove temporary files

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -7,6 +7,9 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1753978370
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
+# MarkLogic version passed from build to enable conditional deps
+ARG ML_VERSION
+
 ###############################################################
 # install libnsl rpm package
 ###############################################################
@@ -23,6 +26,14 @@ RUN microdnf -y update \
 RUN echo "NETWORKING=yes" > /etc/sysconfig/network \
     && microdnf -y install --setopt install_weak_deps=0 gdb redhat-lsb-core initscripts tzdata glibc libstdc++ hostname \
     && microdnf clean all
+
+###############################################################
+# MarkLogic 10 requires 32-bit libstdc++ runtime
+###############################################################
+RUN if [ -n "$ML_VERSION" ] && [ "${ML_VERSION%%.*}" = "10" ]; then \
+        microdnf -y install --setopt install_weak_deps=0 libstdc++.i686 && \
+        microdnf clean all; \
+    fi
 
 
 ###############################################################


### PR DESCRIPTION
### Description
We removed 32 bit version of libstdc++ in one of the previous commits, but it's required for MarkLogic 10.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
