### PR TITLE
MLE-23751 minor pipeline updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,6 @@ LINT_OUTPUT = ''
 SCAN_OUTPUT = ''
 IMAGE_SIZE = 0
 RPMversion = ''
-TIMESTAMP = new Date().format('yyyyMMdd')
 
 // Define local funtions
 
@@ -235,6 +234,8 @@ void buildDockerImage() {
     publishImage="marklogic/marklogic-server-${dockerImageType}:${marklogicVersion}-${env.dockerImageType}"
     mlVerShort=marklogicVersion.split("\\.")[0]
     latestTag="marklogic/marklogic-server-${dockerImageType}:latest-${mlVerShort}"
+    timeStamp = new Date().format('yyyyMMdd')
+    timestamptedTag = builtImage.replace('nightly', timeStamp)
     sh "make build docker_image_type=${dockerImageType} dockerTag=${marklogicVersion}-${env.dockerImageType}-${env.dockerVersion} marklogicVersion=${marklogicVersion} dockerVersion=${env.dockerVersion} build_branch=${env.BRANCH_NAME} package=${RPM} converters=${CONVERTERS}"
     currentBuild.displayName = "#${BUILD_NUMBER}: ${marklogicVersion}-${env.dockerImageType} (${env.dockerVersion})"
 }
@@ -330,7 +331,6 @@ void vulnerabilityScan() {
 void publishToInternalRegistry() {
     withCredentials([usernamePassword(credentialsId: 'builder-credentials-artifactory', passwordVariable: 'docker_password', usernameVariable: 'docker_user')]) {
         sh """
-            timestamptedTag = builtImage.replace('nightly', TIMESTAMP)
             docker logout ${dockerRegistry}
             echo "${docker_password}" | docker login --username ${docker_user} --password-stdin ${dockerRegistry}
             docker tag ${builtImage} ${dockerRegistry}/${builtImage}
@@ -344,7 +344,8 @@ void publishToInternalRegistry() {
         """
         
     }
-    // // Publish to private ECR repository that is used by the performance team. (only ML11)
+    // Publish to private ECR repository that is used by the performance team. (only ML11)
+    // (disabled since it's not needed)
     // if ( params.marklogicVersion == "11" ) {
     //     withCredentials( [[
     //         $class: 'AmazonWebServicesCredentialsBinding',


### PR DESCRIPTION
### Description
- add ML version to blackDuck parameters
- simplify timing and prioritizing ML12 in scheduled builds
- move timestamp in place of "nightly"
    OLD: 12.1.nightly-ubi-rootless-2.2.0-20250827
    NEW: 12.1.20250827-ubi-rootless-2.2.0

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
