### PR TITLE
MLE-24443 update libnsl location

### DIFF
--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1758184547
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1760515502
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 ###############################################################
@@ -12,9 +12,7 @@ LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 ###############################################################
 
 RUN microdnf -y update \
-    && curl -Lso libnsl.rpm https://bed-artifactory.bedford.progress.com:443/artifactory/ml-rpm-release-tierpoint/devdependencies/libnsl-2.34-168.el9_6.23.x86_64.rpm \
-    && rpm -i libnsl.rpm \
-    && rm -f libnsl.rpm
+    && rpm -i https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/Packages/l/libnsl-2.34-168.el9_6.24.x86_64.rpm
 
 ###############################################################
 # install networking, base deps and tzdata for timezone

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1756195339
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1761032271
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 # MarkLogic version passed from build to enable conditional deps
@@ -15,9 +15,7 @@ ARG ML_VERSION
 ###############################################################
 
 RUN microdnf -y update \
-    && curl -Lso libnsl.rpm https://bed-artifactory.bedford.progress.com:443/artifactory/ml-rpm-release-tierpoint/devdependencies/libnsl-2.28-251.el8_10.25.x86_64.rpm \
-    && rpm -i libnsl.rpm \
-    && rm -f libnsl.rpm
+    && rpm -i https://download.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os/Packages/l/libnsl-2.28-251.el8_10.25.x86_64.rpm
 
 ###############################################################
 # install networking, base deps and tzdata for timezone


### PR DESCRIPTION
### Description
We will now use official Rock Linux repository for libnsl library.
Base UBI versions were also updated for latest security fixes.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
