### PR TITLE
MLE-25248 switch to 12.0 branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,7 +197,7 @@ void copyRPMs() {
     else if (marklogicVersion == "12") {
         RPMsuffix = ".nightly-rhel"
         RPMbranch = "b12"
-        RPMversion = "12.1"
+        RPMversion = "12.0"
     }
     else {
         error "Invalid value in marklogicVersion parameter."


### PR DESCRIPTION
### Description
In order to support the release of MarkLogic 12.0.1 we need to switch to 12.0 Docker builds. Once the release is complete, we’ll need to revert the changes.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
