### PR TITLE
MLE-25709 update to ML12.1 and latest UBI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,7 +197,7 @@ void copyRPMs() {
     else if (marklogicVersion == "12") {
         RPMsuffix = ".nightly-rhel"
         RPMbranch = "b12"
-        RPMversion = "12.0"
+        RPMversion = "12.1"
     }
     else {
         error "Invalid value in marklogicVersion parameter."

--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -4,14 +4,15 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1760515502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1764794109
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 ###############################################################
 # install libnsl rpm package
 ###############################################################
 
-RUN rpm -i https://download.rockylinux.org/vault/rocky/9.6/BaseOS/x86_64/os/Packages/l/libnsl-2.34-168.el9_6.23.x86_64.rpm
+RUN microdnf -y update \
+    && rpm -i https://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/Packages/l/libnsl-2.34-231.el9_7.2.x86_64.rpm
 
 ###############################################################
 # install networking, base deps and tzdata for timezone

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1761032271
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1764046129
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 # MarkLogic version passed from build to enable conditional deps


### PR DESCRIPTION
### Description
Switch MarkLogic 12 builds to the latest version. (12.1)
Update to latest UBI base images and fix libnsl dependencies.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
