### PR TITLE
MLE-26717 update dynamic hosts test

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -40,6 +40,11 @@ QA_LICENSE_KEY environment variable needs to be set to a valid license key for l
 Some tests expect certain variable to have valid values. For example, if UBI rootless image is used, specify image type for individual tests:
 `robot --variable TEST_IMAGE:marklogic/marklogic-server-ubi-rootless:internal --variable IMAGE_TYPE:ubi-rootless --test 'Initialized MarkLogic container with config overrides' docker-tests.robot`
 
+### Resource Requirements for Dynamic Host Tests
+The "Dynamic Host Cluster Test" and "Dynamic Host Cluster Concurrency Join Test" require significant system resources as they create 13 containers (3 cluster nodes + 10 dynamic hosts) simultaneously. 
+
+**Note:** These tests may fail with "Connection refused" errors if insufficient resources are allocated. Increase Docker's CPU and memory limits in Docker Desktop/Rancher Desktop preferences if you encounter initialization failures.
+
 For a quick start guide for Robot framework see https://robotframework.org/#getting-started
 Full user guide is available at https://robotframework.org/robotframework/#user-guide
 

--- a/test/keywords.resource
+++ b/test/keywords.resource
@@ -465,15 +465,14 @@ Remove All Dynamic Hosts on port ${port} for group ${group}
     ${host_count}=    Get Length    ${host_ids}
     IF    ${host_count} > 0
         ${auth}    ${headers}=    Generate digest authorization for    ${DEFAULT ADMIN USER}    ${DEFAULT ADMIN PASS}
-        ${header}=    Create Dictionary    Content-type=application/json    Accept=application/json
-        ${dynamic_host_dict}=    Create Dictionary    dynamic-host=${host_ids}
-        ${json_body}=    Create Dictionary    dynamic-hosts=${dynamic_host_dict}
-        # Create session and send DELETE request
+        ${header}=    Create Dictionary    Accept=application/json
+        # Create session and delete hosts one by one using URL parameters
         ${response}=    Create Digest Session    RestSession    url=http://localhost:${port}    headers=${headers}    auth=${auth}
-        ${response}=    DELETE On Session    RestSession
-        ...            url=/manage/v2/clusters/${group}/dynamic-hosts
-        ...            json=${json_body}
-        ...            headers=${header}
+        FOR    ${host_id}    IN    @{host_ids}
+            ${response}=    DELETE On Session    RestSession
+            ...            url=/manage/v2/clusters/${group}/dynamic-hosts/${host_id}
+            ...            headers=${header}
+        END
         Log    Removed ${host_count} dynamic hosts from group ${group}
     ELSE
         Log    No dynamic hosts to remove from group ${group}
@@ -583,7 +582,7 @@ Dynamic Host Join Fails When Token Expires ${group}
     Sleep    10s    # Wait longer than the PT5S token duration
     ${status}=    Run Keyword And Return Status    Init dynamic host 8101 with token ${token}
     Should Be Equal    ${status}    ${FALSE}    Join succeeded with expired token when it should have failed
-    Verify Dynamic Host Count on port 7102 for group ${group} equals 2
+    Verify Dynamic Host Count on port 7102 for group ${group} equals 1
 
 Dynamic Host Join Fails After Token Revoked ${group}
     [Documentation]    Tests that authentication fails after the token is revoked by the admin.
@@ -594,7 +593,7 @@ Dynamic Host Join Fails After Token Revoked ${group}
     ${header}=    Create Dictionary    Content-Type=application/xml
     ${xml_body}=    Set Variable    <dynamic-host-tokens><token>${token}</token></dynamic-host-tokens>
     ${response}=    Create Digest Session    RestSession    url=http://localhost:8002    headers=${headers}    auth=${auth}
-    ${response}=    DELETE On Session    RestSession    url=/manage/v2/clusters/Default/dynamic-host-token    data=${xml_body}    headers=${header}
+    ${response}=    DELETE On Session    RestSession    url=/manage/v2/clusters/${group}/dynamic-host-token    data=${xml_body}    headers=${header}
 
     ${status}=    Run Keyword And Return Status    Init dynamic host 8201 with token ${token}
     Should Be Equal    ${status}    ${FALSE}    Join succeeded with revoked token when it should have failed


### PR DESCRIPTION
### Description
Due to a bug fix in MLE-26547 endpoint /manage/v2/clusters/{id-or-name}/dynamic-hosts/{host-id} now returns correct number of ids so the test had to be updated.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
