### PR TITLE
MLE-27327 Update to latest UBI base images

### DIFF
--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1764794109
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1771346502
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 ###############################################################

--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -1,6 +1,6 @@
 ###############################################################
 #
-#   Copyright © 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+#   Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 ###############################################################
 

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -1,6 +1,6 @@
 ###############################################################
 #
-#   Copyright © 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+#   Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 ###############################################################
 

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1765178706
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1771947229
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 # MarkLogic version passed from build to enable conditional deps


### PR DESCRIPTION
### Description
This pull request updates the base images used in our Dockerfiles to newer versions for both UBI8 and UBI9. This ensures we are using the latest security patches and improvements provided by Red Hat.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
