### PR TITLE
MLE-28076: stabilize UBI libnsl dependency against glibc updates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,6 +28,7 @@ If you are using Copilot/AI to modify this repo, follow the **How Copilot Should
   - Keep the multi-stage + flattened final stage pattern (`COPY --from=builder / /`).
   - Keep ownership/permissions correct for rootless (`marklogic_user:users`, UID 1000).
   - If you add/remove files, update `test/structure-test.yaml` accordingly.
+  - **External RPM pinning**: When pinning external RPMs (e.g., libnsl from AlmaLinux), avoid broad `microdnf -y update` in the same RUN layer, as it can advance glibc and break version compatibility. Use targeted upgrades instead (e.g., `microdnf -y upgrade tzdata`). Test both the dependency image build AND downstream MarkLogic RPM installation.
 - **Env vars / secrets**
   - Keep naming consistent across `README.md`, `docker-compose/*.yaml`, Dockerfiles, and tests.
   - Canonical secret targets: `mldb_admin_username`, `mldb_admin_password`, `mldb_wallet_password`.
@@ -41,6 +42,7 @@ If you are using Copilot/AI to modify this repo, follow the **How Copilot Should
 - Use `make test` for `structure-test` + Robot tests.
 - This repo builds images for `linux/amd64` by default.
 - macOS note: `make structure-test` uses GNU-style `sed -i` (GNU sed syntax); on macOS you may need GNU sed (`gsed`) or run the build/test in a Linux container/VM.
+- **Dependency image changes**: When modifying `marklogic-deps-ubi*:base` Dockerfiles, validate both the dependency image build and the downstream server image RPM installation locally before pushing.
 
 ## Project Overview
 

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -11,11 +11,12 @@ LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 ARG ML_VERSION
 
 ###############################################################
-# install libnsl rpm package
+# install libnsl rpm package from trusted repositories
 ###############################################################
 
-RUN microdnf -y update \
-    && rpm -i https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/libnsl-2.28-251.el8_10.27.x86_64.rpm
+RUN microdnf -y upgrade glibc \
+    && rpm -i https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/libnsl-2.28-251.el8_10.31.x86_64.rpm \
+    && microdnf clean all
 
 ###############################################################
 # install networking, base deps and tzdata for timezone
@@ -23,6 +24,7 @@ RUN microdnf -y update \
 # hadolint ignore=DL3006
 RUN echo "NETWORKING=yes" > /etc/sysconfig/network \
     && microdnf -y install --setopt install_weak_deps=0 gdb redhat-lsb-core initscripts tzdata glibc libstdc++ hostname \
+    && microdnf -y upgrade tzdata \
     && microdnf clean all
 
 ###############################################################


### PR DESCRIPTION
## Summary
- keep libnsl sourced from trusted AlmaLinux repositories
- avoid glibc updates in dependency-image setup steps to prevent libnsl/glibc mismatch
- remove explicit glibc install from UBI8 dependency package list to avoid forcing upgrades

## Why
Docker UBI builds fail when glibc updates ahead of the pinned libnsl package in trusted mirrors. This keeps the dependency pair stable until updated libnsl packages are available.

## Validation
- built dependency images locally:
  - dockerFiles/marklogic-deps-ubi:base
  - dockerFiles/marklogic-deps-ubi9:base
- installed MarkLogic RPMs successfully in both images:
  - MarkLogic-11.3.20260225-rhel.x86_64.rpm
  - MarkLogic-11.3.20260225-rhel9.x86_64.rpm
- ran make lint successfully
