### PR TITLE
MLE-28094: Fix stale test results causing false UNSTABLE builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -484,6 +484,16 @@ pipeline {
     }
 
     stages {
+        // Stage: Remove stale test results from previous builds
+        stage('Clean-Previous-Results') {
+            steps {
+                sh '''
+                    rm -f container-structure-test.xml
+                    rm -rf test/test_results
+                '''
+            }
+        }
+
         // Stage: Perform initial checks (PR status, Jira ID)
         stage('Pre-Build-Check') {
             steps {


### PR DESCRIPTION
## Problem
The `publishTestResults()` function in the `post > always` block runs `junit` against `**/test_results/docker-tests.xml,**/container-structure-test.xml`. When a build skips Docker tests (e.g., `DOCKER_TESTS=false`), stale test result XML files from previous builds remain in the shared workspace. The `junit` step picks up these old files, and if they contain test failures, it incorrectly marks the build as UNSTABLE.

This was observed on develop builds #7302-#7304 where build-only runs (no tests) were marked UNSTABLE due to leftover test results from a prior nightly run that had 4 test failures.

## Fix
Add a `Clean-Previous-Results` stage at the very start of the pipeline to remove stale `container-structure-test.xml` and `test/test_results/` before any stages execute. This ensures each build starts with a clean slate for test results.