### PR TITLE
MLE-28094: Fix stale test results causing false UNSTABLE builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -484,6 +484,16 @@ pipeline {
     }
 
     stages {
+        // Stage: Remove stale test results from previous builds
+        stage('Clean-Previous-Results') {
+            steps {
+                sh '''
+                    rm -f container-structure-test.xml
+                    rm -rf test/test_results
+                '''
+            }
+        }
+
         // Stage: Perform initial checks (PR status, Jira ID)
         stage('Pre-Build-Check') {
             steps {


### PR DESCRIPTION
## Summary

Fixes a Jenkins pipeline bug where builds that skip Docker tests are incorrectly marked as UNSTABLE due to stale test result XML files from a previous build.

## Root Cause

The `publishTestResults()` step in `post > always` uses `junit` to collect `**/test_results/docker-tests.xml` and `**/container-structure-test.xml`. Jenkins reuses workspace directories between builds, so stale XML files from a prior build remain on disk and get picked up in subsequent builds — even when no tests ran.
