### PR TITLE
MLE-24929 Add internal ECR publishing for K8s tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ gitCredID = 'marklogic-builder-github'
 dockerRegistry = 'ml-docker-db-dev-tierpoint.bed-artifactory.bedford.progress.com'
 pdcSbRegistry = 'sandboxpdc.azurecr.io'
 pdcDevRegistry = 'marklogicclouddev.azurecr.io'
+kubeNinjasEcrRegistry = '308453789681.dkr.ecr.us-west-1.amazonaws.com'
 JIRA_ID_PATTERN = /(?i)(MLE)-\d{3,6}/
 JIRA_ID = ''
 LINT_OUTPUT = ''
@@ -386,7 +387,21 @@ void publishToInternalRegistry() {
                 docker push ${pdcDevRegistry}/marklogicdb-custom:${marklogicVersion}-${env.dockerImageType}
             """
         }
-    }
+        // Publish to Kubernetes ECR for testing on EKS
+        def ecrRepo = "${kubeNinjasEcrRegistry}/jenkins-kube-ninjas/marklogic-server-${dockerImageType}"
+        withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
+                        credentialsId: 'KUBE_NINJAS_OPS_AWS_JENKINS',
+                        accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                        secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+            sh """
+                aws ecr get-login-password --region us-west-1 | \\
+                docker login --username AWS --password-stdin ${kubeNinjasEcrRegistry}
+                docker tag ${builtImage} ${ecrRepo}:${marklogicVersion}-${env.dockerImageType}-${env.dockerVersion}
+                docker tag ${builtImage} ${ecrRepo}:latest-${mlVerShort}
+                docker push ${ecrRepo}:${marklogicVersion}-${env.dockerImageType}-${env.dockerVersion}
+                docker push ${ecrRepo}:latest-${mlVerShort}
+            """
+        }
 
     currentBuild.description = "Published"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -402,6 +402,7 @@ void publishToInternalRegistry() {
                 docker push ${ecrRepo}:latest-${mlVerShort}
             """
         }
+	}
 
     currentBuild.description = "Published"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,6 @@ gitCredID = 'marklogic-builder-github'
 dockerRegistry = 'ml-docker-db-dev-tierpoint.bed-artifactory.bedford.progress.com'
 pdcSbRegistry = 'sandboxpdc.azurecr.io'
 pdcDevRegistry = 'marklogicclouddev.azurecr.io'
-kubeNinjasEcrRegistry = '308453789681.dkr.ecr.us-west-1.amazonaws.com'
 JIRA_ID_PATTERN = /(?i)(MLE)-\d{3,6}/
 JIRA_ID = ''
 LINT_OUTPUT = ''
@@ -388,11 +387,15 @@ void publishToInternalRegistry() {
             """
         }
         // Publish to Kubernetes ECR for testing on EKS
-        def ecrRepo = "${kubeNinjasEcrRegistry}/jenkins-kube-ninjas/marklogic-server-${dockerImageType}"
         withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
                         credentialsId: 'KUBE_NINJAS_OPS_AWS_JENKINS',
                         accessKeyVariable: 'AWS_ACCESS_KEY_ID',
                         secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
+            // Resolve account ID via STS — no account number is hardcoded in this file.
+            def awsAccountId = sh(returnStdout: true,
+                script: 'aws sts get-caller-identity --query Account --output text').trim()
+            def kubeNinjasEcrRegistry = "${awsAccountId}.dkr.ecr.us-west-1.amazonaws.com"
+            def ecrRepo = "${kubeNinjasEcrRegistry}/jenkins-kube-ninjas/marklogic-server-${dockerImageType}"
             sh """
                 aws ecr get-login-password --region us-west-1 | \\
                 docker login --username AWS --password-stdin ${kubeNinjasEcrRegistry}


### PR DESCRIPTION
### Description
This PR introduces publishing to an internal repository that will be used to test Kubernetes on EKS.

#### Checklist: 

-  ##### Owner:

- [ ] JIRA_ID as part of branch/PR name
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
