### PR TITLE
MLE-28295: restore redhat-lsb-core for MarkLogic 10 UBI8 images

### DIFF
--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -23,7 +23,7 @@ RUN microdnf -y upgrade glibc \
 ###############################################################
 # hadolint ignore=DL3006
 RUN echo "NETWORKING=yes" > /etc/sysconfig/network \
-    && microdnf -y install --setopt install_weak_deps=0 gdb python3-rpm nss libcap procps-ng python3 libtool-ltdl cpio initscripts tzdata glibc libstdc++ util-linux hostname \
+    && microdnf -y install --setopt install_weak_deps=0 gdb python3-rpm nss libcap procps-ng python3 libtool-ltdl cpio initscripts tzdata glibc libstdc++ util-linux hostname redhat-lsb-core \
     && microdnf -y upgrade tzdata \
     && microdnf clean all
 

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -28,10 +28,10 @@ RUN echo "NETWORKING=yes" > /etc/sysconfig/network \
     && microdnf clean all
 
 ###############################################################
-# MarkLogic 10 requires 32-bit libstdc++ runtime
+# MarkLogic 10 requires 32-bit libstdc++ runtime and redhat-lsb-core
 ###############################################################
 RUN if [ -n "$ML_VERSION" ] && [ "${ML_VERSION%%.*}" = "10" ]; then \
-        microdnf -y install --setopt install_weak_deps=0 libstdc++.i686 && \
+        microdnf -y install --setopt install_weak_deps=0 libstdc++.i686 redhat-lsb-core && \
         microdnf clean all; \
     fi
 


### PR DESCRIPTION
## Summary

Restores conditional installation of `redhat-lsb-core` for MarkLogic 10 UBI8 images, fixing a regression introduced by PR #423.

## Root Cause

PR #423 removed `redhat-lsb-core` unconditionally from `dockerFiles/marklogic-deps-ubi:base`. MarkLogic 10 RPMs still depend on `lsb-core-amd64` (provided by `redhat-lsb-core`), causing Docker builds for ML10 to fail with:

```
error: Failed dependencies:
    lsb-core-amd64 is needed by MarkLogic-10.0-20260406.x86_64
ERROR: process "/bin/sh -c rpm -i /tmp/marklogic-server.rpm ..." did not complete successfully
```

## Fix

Added `redhat-lsb-core` to the existing ML10 conditional block in `dockerFiles/marklogic-deps-ubi:base`, alongside `libstdc++.i686`. This installs `redhat-lsb-core` only when `ML_VERSION` starts with `10`, preserving the intent of PR #423 for ML11+ while restoring compatibility for ML10.

```dockerfile
# MarkLogic 10 requires 32-bit libstdc++ runtime and redhat-lsb-core
RUN if [ -n "$ML_VERSION" ] && [ "${ML_VERSION%%.*}" = "10" ]; then \
        microdnf -y install --setopt install_weak_deps=0 libstdc++.i686 redhat-lsb-core && \
        microdnf clean all; \
    fi
```

## Impact

- Fixes all Docker CI builds for MarkLogic 10 on UBI8 (`ubi`, `ubi-rootless`)
- No change to UBI9 images (`marklogic-deps-ubi9:base` was not modified)
- No change to runtime behaviour or startup scripts

## Related

- Jira: [MLE-28295](https://progresssoftware.atlassian.net/browse/MLE-28295)
- Regression introduced by: #423

[MLE-28295]: https://progresssoftware.atlassian.net/browse/MLE-28295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ