### PR TITLE
MLE-28295: restore redhat-lsb-core for UBI8 images

### DIFF
--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -23,7 +23,7 @@ RUN microdnf -y upgrade glibc \
 ###############################################################
 # hadolint ignore=DL3006
 RUN echo "NETWORKING=yes" > /etc/sysconfig/network \
-    && microdnf -y install --setopt install_weak_deps=0 gdb python3-rpm nss libcap procps-ng python3 libtool-ltdl cpio initscripts tzdata glibc libstdc++ util-linux hostname \
+    && microdnf -y install --setopt install_weak_deps=0 gdb python3-rpm nss libcap procps-ng python3 libtool-ltdl cpio initscripts tzdata glibc libstdc++ util-linux hostname redhat-lsb-core \
     && microdnf -y upgrade tzdata \
     && microdnf clean all
 


### PR DESCRIPTION
## Summary

Restores `redhat-lsb-core` for UBI8 images, fixing a regression introduced by #423.

## Root Cause

PR #423 removed `redhat-lsb-core` unconditionally from `dockerFiles/marklogic-deps-ubi:base`. Both ML10 and ML11 RPMs require the `lsb-core-amd64` package it provides. ML12 does not require it, which is why develop builds using ML12 continued to pass after the regression.

## Fix

`redhat-lsb-core` is restored to the main `microdnf install` line so it is present for all ML versions on UBI8. The existing ML10 conditional block is retained for `libstdc++.i686` only.

## Jenkins Validation (PR-436)

| Build | Version | Type | Result |
|---|---|---|---|
| #5 | ML10 | ubi | ✅ |
| #6 | ML11 | ubi | ✅ |
| #4 | ML12 | ubi | ✅ |
| #1 | ML12 | ubi-rootless | ✅ |

## Related

- Jira: [MLE-28295](https://progresssoftware.atlassian.net/browse/MLE-28295)
- Supersedes: #436
- Regression introduced by: #423

[MLE-28295]: https://progresssoftware.atlassian.net/browse/MLE-28295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ