### PR TITLE
PDP-1182 SECCMP-1797: Switch to pull_request trigger and add top-level permissions

### DIFF
--- a/.github/workflows/pr-workflow.yaml
+++ b/.github/workflows/pr-workflow.yaml
@@ -1,16 +1,15 @@
 name: 🏷️ JIRA ID Validator
 
 on:
-  # Using pull_request_target instead of pull_request to handle PRs from forks
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened, synchronize]
-    # No branch filtering - will run on all PRs
+
+permissions:
+  contents: read
 
 jobs:
   jira-pr-check:
     name: 🏷️ Validate JIRA ticket ID
-    # Use the reusable workflow from the central repository
     uses: marklogic/pr-workflows/.github/workflows/jira-id-check.yml@main
     with:
-      # Pass the PR title from the event context
       pr-title: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## SECCMP-1797: Switch from pull_request_target to pull_request

This workflow only validates JIRA IDs in the PR title. It does not need write permissions or secrets access.

Switching to `pull_request` eliminates the PwnRequest attack surface entirely - no write token, no secrets exposure, regardless of what input is provided.

Also adds explicit `permissions: contents: read` at the workflow level.

Ref: [Preventing pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)