### PR TITLE
MLE-28391: Update Docker base UBI images to the latest

### DIFF
--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1771346502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1775623882
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 ###############################################################

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1771947229
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1775152441
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 # MarkLogic version passed from build to enable conditional deps


### PR DESCRIPTION
## Summary

Update UBI base image tags to the latest available versions to reduce security vulnerability exposure.

## Root cause

The UBI base images pinned in the dependency Dockerfiles were outdated, leaving the images exposed to CVEs addressed in newer UBI releases.

## Fix

- `marklogic-deps-ubi:base`: `ubi8/ubi-minimal:8.10-1771947229` -> `ubi8/ubi-minimal:8.10-1775152441`
- `marklogic-deps-ubi9:base`: `ubi9/ubi-minimal:9.7-1771346502` -> `ubi9/ubi-minimal:9.7-1775623882`

libnsl RPM versions (`el8_10.31`, `el9_7.10`) remain at current values as they are already the latest for their respective RHEL releases.

## Validation

Local lint (`make lint`) passed with no new warnings on the modified Dockerfiles. Jenkins CI builds to follow.

Jira: https://progresssoftware.atlassian.net/browse/MLE-28391