### PR TITLE
MLE-28391: Update Docker base UBI images to the latest (ARM)

### DIFF
--- a/dockerFiles/marklogic-deps-ubi9-arm:base
+++ b/dockerFiles/marklogic-deps-ubi9-arm:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1771346502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1775623882
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 ###############################################################

--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1771346502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1775623882
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 ###############################################################

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1771947229
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1775152441
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 # MarkLogic version passed from build to enable conditional deps


### PR DESCRIPTION
## Summary

Update UBI base image tags to the latest available versions in ARM Dockerfiles to reduce security vulnerability exposure.

## Root cause

The UBI base images pinned in the ARM dependency Dockerfiles were outdated, leaving images exposed to CVEs addressed in newer UBI releases.

## Fix

- `marklogic-deps-ubi9-arm:base`: `ubi9/ubi-minimal:9.7-1771346502` -> `ubi9/ubi-minimal:9.7-1775623882`
- `marklogic-deps-ubi9:base`: `ubi9/ubi-minimal:9.7-1771346502` -> `ubi9/ubi-minimal:9.7-1775623882`
- `marklogic-deps-ubi:base`: `ubi8/ubi-minimal:8.10-1771947229` -> `ubi8/ubi-minimal:8.10-1775152441`

libnsl ARM RPM (`libnsl-2.34-231.el9_7.10.aarch64.rpm`) is already at the latest version. No RPM changes needed.

## Validation

Jenkins CI builds to follow (ubi9-arm and ubi9-rootless-arm for ML 11 and 12).

Jira: https://progresssoftware.atlassian.net/browse/MLE-28391