### PR TITLE
MLE-29349: Fix libnsl version to match upgraded glibc 2.28-251.el8_10.34

### DIFF
--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -15,7 +15,7 @@ ARG ML_VERSION
 ###############################################################
 
 RUN microdnf -y upgrade glibc \
-    && rpm -i https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/libnsl-2.28-251.el8_10.31.x86_64.rpm \
+    && rpm -i https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/libnsl-2.28-251.el8_10.34.x86_64.rpm \
     && microdnf clean all
 
 ###############################################################


### PR DESCRIPTION
Root cause: microdnf -y upgrade glibc advances glibc to 2.28-251.el8_10.34, but the hardcoded libnsl RPM URL in marklogic-deps-ubi:base still pinned version 2.28-251.el8_10.31. The RPM requires glibc(x86-64) = 2.28-251.el8_10.31 exactly, causing a dependency conflict and build failure.

Fix: Update the libnsl RPM URL from 2.28-251.el8_10.31 to 2.28-251.el8_10.34 in dockerFiles/marklogic-deps-ubi:base.

Validation: make lint passes. Jenkins CI UBI builds pending.

Jira: https://progresssoftware.atlassian.net/browse/MLE-29349