### PR TITLE
MLE-29350: Publish MarkLogic 11 nightly Docker images to PDC

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -384,7 +384,7 @@ void publishToInternalRegistry() {
     //         }
     // }
 
-    // Publish to private ACR repositories that are used by PDC. (only ML12)
+    // Publish to private ACR repositories that are used by PDC.
     if ( params.marklogicVersion == "12" ) {
         // Publish to Sandbox PDC registry
         withCredentials([usernamePassword(credentialsId: 'PDC_SANDBOX_USER', passwordVariable: 'docker_password', usernameVariable: 'docker_user')]) {
@@ -396,6 +396,8 @@ void publishToInternalRegistry() {
                 docker push ${pdcSbRegistry}/ml-docker-nightly:${marklogicVersion}-${env.dockerImageType}
             """
         }
+    }
+    if ( params.marklogicVersion == "11" || params.marklogicVersion == "12" ) {
         // Publish to Dev PDC registry
         withCredentials([usernamePassword(credentialsId: 'pdc-azure-cr', passwordVariable: 'docker_password', usernameVariable: 'docker_user')]) {
             sh """
@@ -406,6 +408,8 @@ void publishToInternalRegistry() {
                 docker push ${pdcDevRegistry}/marklogicdb-custom:${marklogicVersion}-${env.dockerImageType}
             """
         }
+    }
+    if ( params.marklogicVersion == "12" ) {
         // Publish to Kubernetes ECR for testing on EKS
         withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
                         credentialsId: 'KUBE_NINJAS_OPS_AWS_JENKINS',


### PR DESCRIPTION
Root cause: the Jenkins publish step only sent MarkLogic 12 images to PDC, so MarkLogic 11 nightly images were never published.

Fix: split the PDC publishing logic so MarkLogic 11 also pushes to the dev Azure ACR registry while MarkLogic 12 keeps the existing sandbox and dev publishing.

Validation: make lint passes locally.