### PR TITLE
Revert MLE-29703 MLE-29709: Fix UBI base image updates and libnsl dependency mismatch (2.2.5)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -470,7 +470,7 @@ pipeline {
 
     parameters {
         string(name: 'emailList', defaultValue: emailList, description: 'List of email for build notification', trim: true)
-        string(name: 'dockerVersion', defaultValue: '2.2.5', description: 'ML Docker version. This value is used as part of the Docker image tag, which is built as ${marklogicVersion}-${dockerImageType}-${dockerVersion}', trim: true)
+        string(name: 'dockerVersion', defaultValue: '2.2.4', description: 'ML Docker version. This value is used as part of the Docker image tag, which is built as ${marklogicVersion}-${dockerImageType}-${dockerVersion}', trim: true)
         choice(name: 'dockerImageType', choices: 'ubi-rootless\nubi\nubi9-rootless\nubi9', description: 'Platform type for Docker image. Will be made part of the docker image tag')
         string(name: 'upgradeDockerImage', defaultValue: '', description: 'Docker image for testing upgrades. Defaults to ubi image if left blank.\n Currently upgrading to ubi-rotless is not supported hence the test is skipped when ubi-rootless image is provided.', trim: true)
         choice(name: 'marklogicVersion', choices: '12\n11\n10', description: 'MarkLogic Server Branch. used to pick appropriate rpm')

--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -4,21 +4,15 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778562320
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1771346502
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 ###############################################################
 # install libnsl rpm package
 ###############################################################
 
-# microdnf -y upgrade glibc brings the UBI9 glibc to a level consistent with the
-# pinned AlmaLinux libnsl build. --nodeps is required because the AlmaLinux libnsl RPM
-# declares an exact glibc version from the AlmaLinux package set that UBI9 repos do not
-# supply verbatim; the symbol ABI is compatible and smoke-tested across all four
-# UBI8/UBI9 x ML11/ML12 build combinations.
-RUN microdnf -y upgrade glibc \
-    && rpm -i --nodeps https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/Packages/libnsl-2.34-231.el9_7.10.x86_64.rpm \
-    && microdnf clean all
+RUN microdnf -y update \
+    && rpm -i https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/Packages/libnsl-2.34-231.el9_7.10.x86_64.rpm
 
 ###############################################################
 # install networking, base deps and tzdata for timezone

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1778735208
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1771947229
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 # MarkLogic version passed from build to enable conditional deps
@@ -14,9 +14,8 @@ ARG ML_VERSION
 # install libnsl rpm package
 ###############################################################
 
-RUN microdnf -y upgrade glibc \
-    && rpm -i https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/libnsl-2.28-251.el8_10.34.x86_64.rpm \
-    && microdnf clean all
+RUN microdnf -y update \
+    && rpm -i https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/libnsl-2.28-251.el8_10.27.x86_64.rpm
 
 ###############################################################
 # install networking, base deps and tzdata for timezone

--- a/test/keywords.resource
+++ b/test/keywords.resource
@@ -12,7 +12,7 @@ Library    DateTime
 ${DEFAULT ADMIN USER}    test_admin
 ${DEFAULT ADMIN PASS}    test_admin_pass
 ${SPEC CHARS ADMIN PASS}    Admin@2$s%^&*!
-${TEST_IMAGE}    %{DOCKER_TEST_IMAGE=progressofficial/marklogic-db:11.3.1-ubi-rootless-2.2.5}
+${TEST_IMAGE}    %{DOCKER_TEST_IMAGE=progressofficial/marklogic-db:11.3.1-ubi-rootless-2.2.4}
 ${UPGRADE_TEST_IMAGE}    progressofficial/marklogic-db:${MARKLOGIC_VERSION}-${IMAGE_TYPE}-${MARKLOGIC_DOCKER_VERSION}
 ${DOCKER TIMEOUT}    300s
 ${LICENSE KEY}    %{QA_LICENSE_KEY=none}
@@ -22,7 +22,7 @@ ${BUILD_BRANCH}    release_2.2.1
 ${IMAGE_TYPE}    ubi-rootless
 ${VOL_NAME}    MarkLogic_vol_1
 ${VOL_INFO}    src=${VOL_NAME},dst=/var/opt/MarkLogic
-${MARKLOGIC_DOCKER_VERSION}    2.2.5
+${MARKLOGIC_DOCKER_VERSION}    2.2.4
 ${TEST_RESULTS_DIR}    test_results
 
 *** Keywords ***


### PR DESCRIPTION
Reverts commit a50402c (PR #447) which was merged prematurely without review approval.