### PR TITLE
MLE-29914: update libnsl repo path to AlmaLinux 9.7

### DIFF
--- a/dockerFiles/marklogic-deps-ubi9-arm:base
+++ b/dockerFiles/marklogic-deps-ubi9-arm:base
@@ -12,7 +12,7 @@ LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 ###############################################################
 
 RUN microdnf -y update \
-    && rpm -i https://download.rockylinux.org/pub/rocky/9/BaseOS/aarch64/os/Packages/l/libnsl-2.34-231.el9_7.10.aarch64.rpm
+    && rpm -i --nodeps https://download.rockylinux.org/pub/rocky/9.7/BaseOS/aarch64/os/Packages/l/libnsl-2.34-231.el9_7.10.aarch64.rpm
 
 ###############################################################
 # install networking, base deps and tzdata for timezone

--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -12,7 +12,7 @@ LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 ###############################################################
 
 RUN microdnf -y update \
-    && rpm -i https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/Packages/libnsl-2.34-231.el9_7.10.x86_64.rpm
+    && rpm -i https://repo.almalinux.org/almalinux/9.7/BaseOS/x86_64/os/Packages/libnsl-2.34-231.el9_7.10.x86_64.rpm
 
 ###############################################################
 # install networking, base deps and tzdata for timezone

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -15,7 +15,7 @@ ARG ML_VERSION
 ###############################################################
 
 RUN microdnf -y upgrade glibc \
-    && rpm -i https://repo.almalinux.org/almalinux/8.10/BaseOS/x86_64/os/Packages/libnsl-2.28-251.el8_10.34.x86_64.rpm \
+    && rpm -i --nodeps https://repo.almalinux.org/almalinux/8.10/BaseOS/x86_64/os/Packages/libnsl-2.28-251.el8_10.34.x86_64.rpm \
     && microdnf clean all
 
 ###############################################################

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -15,7 +15,7 @@ ARG ML_VERSION
 ###############################################################
 
 RUN microdnf -y upgrade glibc \
-    && rpm -i https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/libnsl-2.28-251.el8_10.31.x86_64.rpm \
+    && rpm -i https://repo.almalinux.org/almalinux/8.10/BaseOS/x86_64/os/Packages/libnsl-2.28-251.el8_10.34.x86_64.rpm \
     && microdnf clean all
 
 ###############################################################


### PR DESCRIPTION
Update libnsl RPM download path from the generic /almalinux/9/ mirror to the versioned /almalinux/9.7/ path.

Changes:
- dockerFiles/marklogic-deps-ubi9:base: update libnsl RPM URL from almalinux/9/ to almalinux/9.7/

Jira: https://progresssoftware.atlassian.net/browse/MLE-29914