### PR TITLE
MLE-29914: fix UBI8 tzdata reinstall failure on release/docker-2.2.5

### DIFF
--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -24,6 +24,7 @@ RUN microdnf -y upgrade glibc \
 # hadolint ignore=DL3006
 RUN echo "NETWORKING=yes" > /etc/sysconfig/network \
     && microdnf -y install --setopt install_weak_deps=0 gdb redhat-lsb-core initscripts tzdata glibc libstdc++ hostname \
+    && microdnf -y upgrade tzdata \
     && microdnf clean all
 
 ###############################################################


### PR DESCRIPTION
Fix: microdnf -y reinstall tzdata fails in marklogic-server-ubi:base with:
  Installed package tzdata-2026a-1.el8.noarch not available.

Root cause: the UBI8 base image ships with tzdata-2026a but the UBI8 repo no longer carries that version. The server Dockerfile's 'reinstall tzdata' step cannot find the installed version in the repo and fails with an empty transaction.

Fix: add 'microdnf -y upgrade tzdata' to the deps Dockerfile after the install step, bringing tzdata to the latest available repo version before the server image runs reinstall. This matches the pattern already present on the develop branch.

This failure was pre-existing but hidden behind the libnsl failure fixed in PR #455.

Jira: https://progresssoftware.atlassian.net/browse/MLE-29914