### PR TITLE
MLE-30361: Fix UBI9 libnsl dependency mismatch by updating to AlmaLinux 9.8 repo

### DIFF
--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -11,13 +11,12 @@ LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 # install libnsl rpm package
 ###############################################################
 
-# microdnf -y upgrade glibc brings the UBI9 glibc to a level consistent with the
-# pinned AlmaLinux libnsl build. --nodeps is required because the AlmaLinux libnsl RPM
-# declares an exact glibc version from the AlmaLinux package set that UBI9 repos do not
-# supply verbatim; the symbol ABI is compatible and smoke-tested across all four
-# UBI8/UBI9 x ML11/ML12 build combinations.
+# microdnf -y upgrade glibc brings the UBI9 glibc to el9_8 (currently 2.34-270.el9_8).
+# --nodeps is required because the AlmaLinux libnsl RPM declares a dependency on
+# AlmaLinux's glibc packaging; UBI9 provides the same ABI but different package provenance.
+# The AlmaLinux 9.8 libnsl version is kept in sync with the glibc version UBI9 pulls.
 RUN microdnf -y upgrade glibc \
-    && rpm -i --nodeps https://repo.almalinux.org/almalinux/9.7/BaseOS/x86_64/os/Packages/libnsl-2.34-231.el9_7.10.x86_64.rpm \
+    && rpm -i --nodeps https://repo.almalinux.org/almalinux/9.8/BaseOS/x86_64/os/Packages/libnsl-2.34-270.el9_8.x86_64.rpm \
     && microdnf clean all
 
 ###############################################################


### PR DESCRIPTION
## Summary

UBI9 x86_64 builds have been failing since the UBI9 base image moved to glibc 2.34-270.el9_8. The hardcoded libnsl URL still pointed to the AlmaLinux 9.7 repo, which no longer serves that file, causing a 404 during the dependency image build.

## Root Cause

`microdnf -y upgrade glibc` in `dockerFiles/marklogic-deps-ubi9:base` now installs glibc 2.34-270.el9_8 (UBI9 repos moved from el9_7 to el9_8). The libnsl RPM was pinned to AlmaLinux 9.7 (libnsl-2.34-231.el9_7.10.x86_64.rpm) which is no longer available at that URL.

## Fix

Updated the libnsl RPM URL to AlmaLinux 9.8:
- Old: `https://repo.almalinux.org/almalinux/9.7/BaseOS/x86_64/os/Packages/libnsl-2.34-231.el9_7.10.x86_64.rpm`
- New: `https://repo.almalinux.org/almalinux/9.8/BaseOS/x86_64/os/Packages/libnsl-2.34-270.el9_8.x86_64.rpm`

The AlmaLinux 9.8 libnsl version (2.34-270.el9_8) matches the glibc version now provided by UBI9, maintaining ABI compatibility.

Note: The equivalent fix for aarch64 is in PR #459 targeting Docker-ARM-support.

## Testing

- Local Docker build: `make build docker_image_type=ubi9` - PASS
- Lint (Hadolint + ShellCheck): PASS
- Structure tests (6/6): PASS

Jira: MLE-30361