### PR TITLE
MLE-30361: Fix aarch64 UBI9 libnsl dependency mismatch by updating to Rocky Linux 9.8 repo

### DIFF
--- a/dockerFiles/marklogic-deps-ubi9-arm:base
+++ b/dockerFiles/marklogic-deps-ubi9-arm:base
@@ -12,7 +12,7 @@ LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 ###############################################################
 
 RUN microdnf -y update \
-    && rpm -i --nodeps https://download.rockylinux.org/pub/rocky/9.7/BaseOS/aarch64/os/Packages/l/libnsl-2.34-231.el9_7.10.aarch64.rpm
+    && rpm -i --nodeps https://download.rockylinux.org/pub/rocky/9.8/BaseOS/aarch64/os/Packages/l/libnsl-2.34-270.el9_8.aarch64.rpm
 
 ###############################################################
 # install networking, base deps and tzdata for timezone


### PR DESCRIPTION
## Summary

UBI9 aarch64 builds have been failing since the UBI9 base image moved to glibc 2.34-270.el9_8. The hardcoded libnsl URL still pointed to the Rocky Linux 9.7 repo, which no longer serves that file, causing a 404 during the dependency image build.

## Root Cause

`microdnf -y update` in `dockerFiles/marklogic-deps-ubi9-arm:base` now upgrades glibc to 2.34-270.el9_8. The libnsl RPM was pinned to Rocky Linux 9.7 (libnsl-2.34-231.el9_7.10.aarch64.rpm) which is no longer available at that URL.

## Fix

Updated the libnsl RPM URL to Rocky Linux 9.8:
- Old: `https://download.rockylinux.org/pub/rocky/9.7/BaseOS/aarch64/os/Packages/l/libnsl-2.34-231.el9_7.10.aarch64.rpm`
- New: `https://download.rockylinux.org/pub/rocky/9.8/BaseOS/aarch64/os/Packages/l/libnsl-2.34-270.el9_8.aarch64.rpm`

The Rocky Linux 9.8 libnsl version (2.34-270.el9_8) matches the glibc version now provided by UBI9, maintaining ABI compatibility.

Note: The equivalent fix for x86_64 is in PR #458 targeting develop.

Jira: MLE-30361