### PR TITLE
MLE-26874 optimize kubeninjas pipelines for SBOM generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -623,7 +623,8 @@ pipeline {
             when {
                 anyOf {
                         branch 'develop'
-                        expression { return params.PUBLISH_IMAGE }
+                        branch 'master'
+                        branch 'release*'
                     }
             }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -622,9 +622,7 @@ pipeline {
         stage('BlackDuck-Scan') {
             when {
                 anyOf {
-                        branch 'develop'
-                        branch 'master'
-                        branch 'release*'
+                        branch pattern: '^(develop|master|release.*)$', comparator: 'REGEXP'
                     }
             }
             steps {


### PR DESCRIPTION
### Description
BlackDuck scan will only be triggered from master/develop/release* branches in order to keep the number of scans for SBOM generation to a manageable level.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
