### PR TITLE
MLE-31723: fix publish image race

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -767,6 +767,9 @@ pipeline {
                 script {
                     unstash 'built-image-archive'
                     // Load image from tar if not already available (applies to all build types)
+                    // Node's Docker daemon is shared with other concurrent builds, so only ever
+                    // trust the exact, fully-qualified tag - never a loose repo/type match, which
+                    // could resolve to a different build's image (e.g. a different marklogicVersion).
                     sh """
                         if ! docker image inspect ${builtImage} &>/dev/null; then
                             echo "Image not found locally, loading from ${WORKSPACE}/${GRAVITON3_IMAGE_ARCHIVE}..."
@@ -774,23 +777,11 @@ pipeline {
                         else
                             echo "Image ${builtImage} already available locally"
                         fi
+                        docker image inspect ${builtImage} >/dev/null
                     """
-                    
-                    // If builtImage doesn't exist, find the loaded image by repo pattern
-                    def actualImage = sh(
-                        returnStdout: true,
-                        script: """docker images --format 'table {{.Repository}}:{{.Tag}}' | grep "marklogic/marklogic-server-${dockerImageType}:" | head -1"""
-                    ).trim()
-                    
-                    if (!actualImage) {
-                        actualImage = builtImage
-                        echo "Using builtImage tag: ${actualImage}"
-                    } else {
-                        echo "Found loaded image: ${actualImage}"
-                    }
-                    
+
                     // Store for use in publishToInternalRegistry
-                    env.IMAGE_TO_PUBLISH = actualImage
+                    env.IMAGE_TO_PUBLISH = builtImage
                 }
                 publishToInternalRegistry()
                 // Trigger downstream QA image build job

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -274,12 +274,28 @@ void copyRPMs() {
         fi
     """
     script {
-        // Get the RPM and Converters file names for the correct architecture (archSuffix already defined above)
-        // Use newest files so we don't accidentally pick a stale RPM left from a previous run.
-        RPM = sh(returnStdout: true, script: "cd src; ls -1t MarkLogic-*.${archSuffix}.rpm 2>/dev/null | head -1").trim()
-        CONVERTERS = sh(returnStdout: true, script: "cd src; (ls -1t MarkLogicConverters-*.${archSuffix}.rpm 2>/dev/null || ls -1t MarkLogicConverters-*.rpm 2>/dev/null) | head -1").trim()
+        // Select RPMs using version-specific patterns first to avoid picking another concurrent build's artifacts.
+        RPM = sh(returnStdout: true, script: "cd src; ls -1t MarkLogic-${RPMversion}*.${archSuffix}.rpm 2>/dev/null | head -1").trim()
+        if (!RPM) {
+            RPM = sh(returnStdout: true, script: "cd src; ls -1t MarkLogic-*.${archSuffix}.rpm 2>/dev/null | head -1").trim()
+        }
+
+        CONVERTERS = sh(returnStdout: true, script: "cd src; ls -1t MarkLogicConverters-${RPMversion}*.${archSuffix}.rpm 2>/dev/null | head -1").trim()
+        if (!CONVERTERS) {
+            CONVERTERS = sh(returnStdout: true, script: "cd src; (ls -1t MarkLogicConverters-*.${archSuffix}.rpm 2>/dev/null || ls -1t MarkLogicConverters-*.rpm 2>/dev/null) | head -1").trim()
+        }
+
+        if (!RPM) {
+            error "No MarkLogic RPM found in src/ for architecture ${archSuffix}"
+        }
+
         // Extract MarkLogic version from RPM file name (handle both x86_64 and aarch64)
         marklogicVersion = sh(returnStdout: true, script: "echo ${RPM} | awk -F 'MarkLogic-' '{print \$2;}' | awk -F '.x86_64.rpm' '{print \$1;}' | awk -F '.aarch64.rpm' '{print \$1;}' | awk -F '-rhel' '{print \$1;}'").trim()
+
+        if (!marklogicVersion.startsWith("${params.marklogicVersion}.")) {
+            error "Resolved RPM version '${marklogicVersion}' does not match requested marklogicVersion '${params.marklogicVersion}'"
+        }
+
         echo "Selected server RPM: ${RPM}"
         echo "Selected converters RPM: ${CONVERTERS}"
         echo "Derived MarkLogic version from RPM: ${marklogicVersion}"


### PR DESCRIPTION
### Description

This pull request strengthens the artifact selection and image handling logic in the `Jenkinsfile` to ensure that the correct build artifacts are used, especially in environments with concurrent builds. The main improvements are tighter version matching for RPM selection and more robust Docker image handling to prevent accidental cross-build contamination.

**Artifact selection improvements:**

* Updated RPM and Converters selection to first match version-specific patterns, reducing the risk of picking up artifacts from other concurrent builds. If no version-specific file is found, it falls back to the previous pattern.
* Added explicit error handling if no RPM is found, and added a check to ensure the resolved RPM version matches the requested `marklogicVersion` parameter, failing fast if there is a mismatch.

**Docker image handling improvements:**

* Removed the logic that searched for a loosely-matching Docker image tag after loading from the archive. Now, only the exact, fully-qualified image tag (`builtImage`) is used and trusted, preventing accidental use of images from other builds.
* Added a comment and an explicit `docker image inspect` command to verify that the expected image is present after loading, further ensuring correctness.

#### Checklist: 

-  ##### Owner:

- [ ] JIRA_ID as part of branch/PR name
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
