### PR TITLE
MLE-31921 Scan latest tag in Black Duck

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -492,10 +492,13 @@ void publishToInternalRegistry() {
 
 /**
  * Triggers a BlackDuck scan job for the published image.
+ * Scans the rolling latest-<majorVersion> tag (not the per-build version tag) so each
+ * scan overwrites the same BlackDuck code location instead of accumulating a new one
+ * per MarkLogic minor version release.
  * Runs asynchronously (wait: false).
  */
 void scanWithBlackDuck() {
-    build job: 'securityscans/Blackduck/KubeNinjas/docker', wait: false, parameters: [ string(name: 'BRANCH', value: "${env.BRANCH_NAME}"), string(name: 'CONTAINER_IMAGES', value: "${dockerRegistry}/${publishImage}"), string(name: 'ML_VER', value: "${params.marklogicVersion}"), string(name: 'DOCKER_TYPE', value: "${params.dockerImageType}") ]
+    build job: 'securityscans/Blackduck/KubeNinjas/docker', wait: false, parameters: [ string(name: 'BRANCH', value: "${env.BRANCH_NAME}"), string(name: 'CONTAINER_IMAGES', value: "${dockerRegistry}/${latestTag}"), string(name: 'ML_VER', value: "${params.marklogicVersion}"), string(name: 'DOCKER_TYPE', value: "${params.dockerImageType}") ]
 }
 
 /**


### PR DESCRIPTION
### Description

Currently this pipeline sends dated tags to BlackDuck which are unique and remain under the branch indefinitely. This means that BlackDuck will keep old vulnerabilities under a version/branch until the scan is deleted.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [ ] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
