### PR TITLE
MLE-29711: Upgrade Docker UBI9 base image from 9.7 to 9.8

### DIFF
--- a/dockerFiles/marklogic-deps-ubi9-arm:base
+++ b/dockerFiles/marklogic-deps-ubi9-arm:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1775623882
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 ###############################################################
@@ -12,7 +12,7 @@ LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 ###############################################################
 
 RUN microdnf -y upgrade glibc \
-    && rpm -i --nodeps https://download.rockylinux.org/pub/rocky/9.8/BaseOS/aarch64/os/Packages/l/libnsl-2.34-270.el9_8.aarch64.rpm \
+    && rpm -i https://download.rockylinux.org/pub/rocky/9.8/BaseOS/aarch64/os/Packages/l/libnsl-2.34-275.el9_8.aarch64.rpm \
     && microdnf clean all
 
 ###############################################################

--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -4,19 +4,17 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778562320
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1786987521
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 ###############################################################
 # install libnsl rpm package
 ###############################################################
 
-# microdnf -y upgrade glibc brings the UBI9 glibc to el9_8 (currently 2.34-270.el9_8).
-# --nodeps is required because the AlmaLinux libnsl RPM declares a dependency on
-# AlmaLinux's glibc packaging; UBI9 provides the same ABI but different package provenance.
-# The AlmaLinux 9.8 libnsl version is kept in sync with the glibc version UBI9 pulls.
+# microdnf -y upgrade glibc brings the UBI9 glibc to el9_8.
+# The Rocky Linux 9.8 libnsl version is kept in sync with the glibc version UBI9 pulls.
 RUN microdnf -y upgrade glibc \
-    && rpm -i --nodeps https://repo.almalinux.org/almalinux/9.8/BaseOS/x86_64/os/Packages/libnsl-2.34-270.el9_8.x86_64.rpm \
+    && rpm -i https://download.rockylinux.org/pub/rocky/9.8/BaseOS/x86_64/os/Packages/l/libnsl-2.34-275.el9_8.x86_64.rpm \
     && microdnf clean all
 
 ###############################################################

--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -11,7 +11,7 @@ LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 # install libnsl rpm package
 ###############################################################
 
-# microdnf -y upgrade glibc brings the UBI9 glibc to el9_8.
+# microdnf -y upgrade glibc ensures glibc is updated to the patch level required by the pinned libnsl RPM.
 # The Rocky Linux 9.8 libnsl version is kept in sync with the glibc version UBI9 pulls.
 RUN microdnf -y upgrade glibc \
     && rpm -i https://download.rockylinux.org/pub/rocky/9.8/BaseOS/x86_64/os/Packages/l/libnsl-2.34-275.el9_8.x86_64.rpm \

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -4,7 +4,7 @@
 #
 ###############################################################
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1778735208
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1787081751
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 # MarkLogic version passed from build to enable conditional deps
@@ -15,7 +15,7 @@ ARG ML_VERSION
 ###############################################################
 
 RUN microdnf -y upgrade glibc \
-    && rpm -i --nodeps https://repo.almalinux.org/almalinux/8.10/BaseOS/x86_64/os/Packages/libnsl-2.28-251.el8_10.34.x86_64.rpm \
+    && rpm -i https://download.rockylinux.org/pub/rocky/8.10/BaseOS/x86_64/os/Packages/l/libnsl-2.28-251.el8_10.40.x86_64.rpm \
     && microdnf clean all
 
 ###############################################################


### PR DESCRIPTION
## Summary
Upgrade the UBI9 base image from 9.7 to 9.8 (and UBI8 base image to latest stable 8.10) across Dockerfiles and build definitions to incorporate the latest upstream security updates and package fixes.

## Root cause
The base UBI9 and UBI8 image versions needed an upgrade to maintain support and include recent security patches and compatible libnsl packages.

## Fix
- Updated UBI9 minimal base image to `9.8-1786987521` (x86_64 and arm64).
- Updated UBI8 minimal base image to `8.10-1787081751` (x86_64).
- Switched to Rocky Linux `libnsl` package URLs without `--nodeps` for clean dependency resolution.

## Validation
- make lint: PASS (0 issues on all modified files)
- Docker builds for UBI8 and UBI9 minimal dependency images (x86_64 and arm64): PASS
- Downstream MarkLogic server builds: PASS (verified manually)