### PR TITLE
MLE-28426: Copyright validator fails due to mismatch in (c) symbol

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-// Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+// Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 // This Jenkinsfile defines internal MarkLogic build pipeline.
 // The pipeline builds, tests, scans, and optionally publishes MarkLogic Docker images.
 // It can be triggered manually, by pull requests, or on a schedule.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved. 
+Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved. 
 
 The marklogic-docker image is licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at 
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 dockerTag?=internal
 package?=MarkLogic.rpm
 repo_dir=marklogic

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,6 +1,6 @@
 MarkLogic® Docker Container Image v2
 
-Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  
 This project is licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with the License. You may obtain a copy of the License at
 

--- a/docker-compose/marklogic-multi-node.yaml
+++ b/docker-compose/marklogic-multi-node.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #Docker compose file sample to setup a three node cluster
 version: '3.6'
 services:

--- a/docker-compose/marklogic-single-node.yaml
+++ b/docker-compose/marklogic-single-node.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #Docker compose file sample to setup single node cluster
 version: '3.6'
 services:

--- a/dockerFiles/marklogic-deps-ubi9-arm:base
+++ b/dockerFiles/marklogic-deps-ubi9-arm:base
@@ -1,6 +1,6 @@
 ###############################################################
 #
-#   Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+#   Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 ###############################################################
 

--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -1,6 +1,6 @@
 ###############################################################
 #
-#   Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+#   Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 ###############################################################
 

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -1,6 +1,6 @@
 ###############################################################
 #
-#   Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+#   Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 ###############################################################
 

--- a/dockerFiles/marklogic-server-ubi-rootless:base
+++ b/dockerFiles/marklogic-server-ubi-rootless:base
@@ -1,6 +1,6 @@
 ###############################################################
 #
-#   Copyright © 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+#   Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 ###############################################################
 

--- a/dockerFiles/marklogic-server-ubi9-arm:base
+++ b/dockerFiles/marklogic-server-ubi9-arm:base
@@ -1,6 +1,6 @@
 ###############################################################
 #
-#   Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+#   Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 ###############################################################
 

--- a/dockerFiles/marklogic-server-ubi:base
+++ b/dockerFiles/marklogic-server-ubi:base
@@ -1,6 +1,6 @@
 ###############################################################
 #
-#   Copyright © 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+#   Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 ###############################################################
 

--- a/src/scripts/start-marklogic-rootless.sh
+++ b/src/scripts/start-marklogic-rootless.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 ###############################################################
 #
-#   Copyright © 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+#   Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 ###############################################################
 #   Initialise and start MarkLogic server

--- a/src/scripts/start-marklogic.sh
+++ b/src/scripts/start-marklogic.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 ###############################################################
 #
-#   Copyright © 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+#   Copyright (c) 2018-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 ###############################################################
 #   Initialise and start MarkLogic server

--- a/test/compose-1node-bootstrap-env-creds.yaml
+++ b/test/compose-1node-bootstrap-env-creds.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Compose scenario: Single bootstrap node with admin credentials from environment variables.
 version: '3.6'
 services:

--- a/test/compose-1node-self-join.yaml
+++ b/test/compose-1node-self-join.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Compose scenario: Single node configured to join itself to validate self-join handling.
 version: '3.6'
 services:

--- a/test/compose-2node-bootstrap-only.yaml
+++ b/test/compose-2node-bootstrap-only.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Compose scenario: Bootstrap-only node used as base for follow-up join tests.
 version: '3.6'
 services:

--- a/test/compose-2node-cluster-env-creds.yaml
+++ b/test/compose-2node-cluster-env-creds.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Compose scenario: Two-node cluster using admin credentials from environment variables.
 version: '3.6'
 services:

--- a/test/compose-2node-invalid-bootstrap-host.yaml
+++ b/test/compose-2node-invalid-bootstrap-host.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Compose scenario: Two-node deployment with an invalid bootstrap host name for node2.
 version: '3.6'
 services:

--- a/test/compose-2node-join-enode-secrets.yaml
+++ b/test/compose-2node-join-enode-secrets.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Compose scenario: Second node joins bootstrap and is assigned to the enode group using secrets.
 version: '3.6'
 services:

--- a/test/compose-2node-join-https-invalid-tls.yaml
+++ b/test/compose-2node-join-https-invalid-tls.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Compose scenario: HTTPS join with invalid MARKLOGIC_JOIN_TLS_ENABLED value.
 version: '3.6'
 services:

--- a/test/compose-2node-join-https-missing-cacert.yaml
+++ b/test/compose-2node-join-https-missing-cacert.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Compose scenario: HTTPS join with missing MARKLOGIC_JOIN_CACERT_FILE value.
 version: '3.6'
 services:

--- a/test/compose-2node-join-https-secrets.yaml
+++ b/test/compose-2node-join-https-secrets.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Compose scenario: Second node joins bootstrap over HTTPS using username/password/CA secrets.
 version: '3.6'
 services:

--- a/test/compose-2node-second-uncoupled.yaml
+++ b/test/compose-2node-second-uncoupled.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Compose scenario: Two-node deployment where second node is initialized but does not join the cluster.
 version: '3.6'
 services:

--- a/test/compose-2node-second-uninitialized.yaml
+++ b/test/compose-2node-second-uninitialized.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Compose scenario: Two-node deployment where second node remains uninitialized.
 version: '3.6'
 services:

--- a/test/compose-2x2node-clusters-secrets.yaml
+++ b/test/compose-2x2node-clusters-secrets.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Compose scenario: Two separate 2-node clusters with secrets for cross-cluster coupling tests.
 version: '3.6'
 services:

--- a/test/compose-3core-11dynamic-hosts.yaml
+++ b/test/compose-3core-11dynamic-hosts.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # Compose scenario: Dynamic host test topology with 3 core nodes and 11 dynamic nodes.
 version: '3.6'
 services:

--- a/test/docker-tests.robot
+++ b/test/docker-tests.robot
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 *** Settings ***
 Resource         keywords.resource
 Documentation    Test all initialization options using Docker run and Docker Compose.

--- a/test/keywords.resource
+++ b/test/keywords.resource
@@ -1,4 +1,4 @@
-# Copyright © 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+# Copyright (c) 2018-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 *** Settings ***
 Library    Process
 Library    String


### PR DESCRIPTION
## Summary
Replace unicode copyright symbols (©) with standard ASCII (c) across all affected files in the repository to resolve copyright validator mismatches.

## Root cause
The copyright validation checks expect ASCII (c) notation, causing validation failures when non-ASCII © characters are present.

## Fix
Replaced all occurrences of non-ASCII copyright symbols with standard ASCII (c) across all 29 affected files.

## Validation
- make lint: PASS (0 ShellCheck errors/warnings)
- Copyright symbol check: PASS (0 remaining non-ASCII copyright characters across all 29 files)