### PR TITLE
MLE-32285 remove duplicate commands

### DIFF
--- a/dockerFiles/marklogic-server-ubi-rootless:base
+++ b/dockerFiles/marklogic-server-ubi-rootless:base
@@ -163,17 +163,7 @@ RUN if [ -s /tmp/converters.rpm ]; then chown ${ML_USER}:users /tmp/converters.r
 # Configure GDB for debugging and set capabilities for non-root usage
 ###############################################################
 RUN microdnf -y install libcap \
-    && setcap cap_sys_ptrace+ep $(readlink -f /usr/bin/gdb) \
-    && echo "set auto-load safe-path /" > /home/${ML_USER}/.gdbinit \
-    && chown ${ML_USER}:users /home/${ML_USER}/.gdbinit \
-    && chmod 644 /home/${ML_USER}/.gdbinit \
-    && microdnf clean all
-
-###############################################################
-# Configure GDB for debugging and set capabilities for non-root usage
-###############################################################
-RUN microdnf -y install libcap \
-    && setcap cap_sys_ptrace+ep $(readlink -f /usr/bin/gdb) \
+    && setcap cap_sys_ptrace+ep "$(readlink -f /usr/bin/gdb)" \
     && echo "set auto-load safe-path /" > /home/${ML_USER}/.gdbinit \
     && chown ${ML_USER}:users /home/${ML_USER}/.gdbinit \
     && chmod 644 /home/${ML_USER}/.gdbinit \


### PR DESCRIPTION
### Description
“Configure GDB for debugging” section in dockerFiles/marklogic-server-ubi-rootless:base file in marklogic-docker repo contains a duplicate config. Lines 162-180.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
