### PR TITLE
MLE-32332: pass pinned UBI base image to BlackDuck scan job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -488,8 +488,10 @@ void publishToInternalRegistry() {
  * Runs asynchronously (wait: false).
  */
 void scanWithBlackDuck() {
-    def depsDockerfile = params.dockerImageType.contains('ubi9-arm') ? 'dockerFiles/marklogic-deps-ubi9-arm:base' :
-        params.dockerImageType.contains('ubi9') ? 'dockerFiles/marklogic-deps-ubi9:base' : 'dockerFiles/marklogic-deps-ubi:base'
+    def isUbi9 = params.dockerImageType.contains('ubi9')
+    def isArm = params.dockerImageType.contains('arm')
+    def depsDockerfile = (isUbi9 && isArm) ? 'dockerFiles/marklogic-deps-ubi9-arm:base' :
+        isUbi9 ? 'dockerFiles/marklogic-deps-ubi9:base' : 'dockerFiles/marklogic-deps-ubi:base'
     def baseImageToExclude = sh(returnStdout: true, script: "grep -m1 '^FROM' ${depsDockerfile} | awk '{print \$2}'").trim()
     build job: 'securityscans/Blackduck/KubeNinjas/docker', wait: false, parameters: [ string(name: 'BRANCH', value: "${env.BRANCH_NAME}"), string(name: 'CONTAINER_IMAGES', value: "${dockerRegistry}/${latestTag}"), string(name: 'ML_VER', value: "${params.marklogicVersion}"), string(name: 'DOCKER_TYPE', value: "${params.dockerImageType}"), string(name: 'BASE_IMAGE_TO_EXCLUDE', value: "${baseImageToExclude}") ]
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -483,10 +483,15 @@ void publishToInternalRegistry() {
  * Scans the rolling latest-<majorVersion> tag (not the per-build version tag) so each
  * scan overwrites the same BlackDuck code location instead of accumulating a new one
  * per MarkLogic minor version release.
+ * Passes the pinned UBI base image (read from the matching marklogic-deps Dockerfile's FROM
+ * line) so BlackDuck can run an additional scan excluding base image components.
  * Runs asynchronously (wait: false).
  */
 void scanWithBlackDuck() {
-    build job: 'securityscans/Blackduck/KubeNinjas/docker', wait: false, parameters: [ string(name: 'BRANCH', value: "${env.BRANCH_NAME}"), string(name: 'CONTAINER_IMAGES', value: "${dockerRegistry}/${latestTag}"), string(name: 'ML_VER', value: "${params.marklogicVersion}"), string(name: 'DOCKER_TYPE', value: "${params.dockerImageType}") ]
+    def depsDockerfile = params.dockerImageType.contains('ubi9-arm') ? 'dockerFiles/marklogic-deps-ubi9-arm:base' :
+        params.dockerImageType.contains('ubi9') ? 'dockerFiles/marklogic-deps-ubi9:base' : 'dockerFiles/marklogic-deps-ubi:base'
+    def baseImageToExclude = sh(returnStdout: true, script: "grep -m1 '^FROM' ${depsDockerfile} | awk '{print \$2}'").trim()
+    build job: 'securityscans/Blackduck/KubeNinjas/docker', wait: false, parameters: [ string(name: 'BRANCH', value: "${env.BRANCH_NAME}"), string(name: 'CONTAINER_IMAGES', value: "${dockerRegistry}/${latestTag}"), string(name: 'ML_VER', value: "${params.marklogicVersion}"), string(name: 'DOCKER_TYPE', value: "${params.dockerImageType}"), string(name: 'BASE_IMAGE_TO_EXCLUDE', value: "${baseImageToExclude}") ]
 }
 
 /**


### PR DESCRIPTION
### Description

Resolves the base image from the matching marklogic-deps Dockerfile's FROM line (so it always matches whatever is currently pinned) and passes it as BASE_IMAGE_TO_EXCLUDE, enabling the downstream pipeline's additional filtered scan that excludes base image components.

#### Checklist: 

-  ##### Owner:

- [x] JIRA_ID as part of branch/PR name
- [x] Rebase the branch with upstream
- [x] Squashed all commits into a single commit
- [x] Added Tests
  
- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Added to Release Wiki/Jira
